### PR TITLE
Refactor to change default behavior to output subtitle only

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
 
-**koffee** is a tool that automates the translation and subtitling of Korean<>English videos.
+**koffee** is a tool that automates the translation and subtitling of Korean and Japanese video and audio files to English.
 
 ## Dependencies
 
@@ -27,7 +27,7 @@ pip install git+https://github.com/andrewwkimm/koffee
 
 ## Quick start
 
-All that is needed is a working video or audio file and the translated video, or subtitle file for audios, will be outputted to the current directory.
+All that is needed is a working video or audio file and the translated subtitle file will be outputted to the current directory.
 
 ```console
 koffee some_dir/some_video_file.mp4
@@ -75,6 +75,7 @@ Refer below for a list of all commands and parameters.
     --version, -v               Display application version.
     --verbose, -V               Print debug logs.
     --subtitles, -s             Write the translated subtitle file to disk.
+    --overlay-video, ov             Overlay subtitles onto a video file.
 
 ## Contributing
 

--- a/features/api.feature
+++ b/features/api.feature
@@ -1,10 +1,10 @@
 Feature: koffee APIs
 
-    Scenario Outline: User gets a translated video file
+    Scenario Outline: User gets a translated subtitle file
         Given a user has a basic <language> video file
         And the user sets the output directory to <path>
         When the user calls the koffee API
-        Then the user receives a built video file
+        Then the user receives a subtitle file
 
     Examples: language
         | language | path        |

--- a/features/steps/api.py
+++ b/features/steps/api.py
@@ -10,6 +10,8 @@ from behave.runner import Context
 from koffee.exceptions import InvalidVideoFileError
 from koffee.translate import translate
 
+SUBTITLE_EXTENSIONS = {".srt", ".vtt"}
+
 
 @given("a user has a basic {language} video file")
 def step_given(context: Context, language: str) -> None:
@@ -24,7 +26,7 @@ def step_given(context: Context, language: str) -> None:
 
 @given("the user sets the output directory to {path}")
 def step_impl(context: Context, path) -> None:
-    """Sets the output directory for the translated video file."""
+    """Sets the output directory for the translated file."""
     context.output_dir = Path(path)
 
 
@@ -44,10 +46,11 @@ def step_impl(context: Context):
         context.error = error
 
 
-@then("the user receives a built video file")
+@then("the user receives a subtitle file")
 def step_impl(context: Context):
-    """Assert that the output file exists."""
+    """Assert that the output subtitle file exists with a valid subtitle extension."""
     assert context.output_file_path.exists()
+    assert context.output_file_path.suffix in SUBTITLE_EXTENSIONS
 
 
 @given("the user corrupts the file somehow")

--- a/src/koffee/cli.py
+++ b/src/koffee/cli.py
@@ -48,9 +48,9 @@ def cli(  # noqa: PLR0913
     subtitle_format: Annotated[
         str, Parameter(name=("--subtitle_format", "-sf"))
     ] = options.subtitle_format,
-    subtitles: Annotated[
-        bool, Parameter(name=("--subtitles", "-s"), group=options_group)
-    ] = options.subtitles,
+    overlay_video: Annotated[
+        bool, Parameter(name=("--overlay-video", "-ov"), group=options_group)
+    ] = options.overlay_video,
     translation_backend: Annotated[
         str, Parameter(name=("--translation_backend", "-tb"))
     ] = options.translation_backend,
@@ -65,7 +65,7 @@ def cli(  # noqa: PLR0913
     Parameters
     ----------
     file_path: Path
-        Path to the video file
+        Path to the video or audio file
     compute_type: str
         Type to use for computation
     device: str
@@ -78,8 +78,9 @@ def cli(  # noqa: PLR0913
         Name of the output file
     subtitle_format: str
         Format to use for the subtitles
-    subtitles: bool
-        Write the translated subtitle file to disk
+    overlay_video: bool
+        Overlay subtitles onto the video file instead of outputting a subtitle file.
+        Only valid for video file inputs.
     target_language: str
         Language to which the video should be translated
     translation_backend: str
@@ -99,8 +100,8 @@ def cli(  # noqa: PLR0913
         model=model,
         output_dir=output_dir,
         output_name=output_name,
+        overlay_video=overlay_video,
         subtitle_format=subtitle_format,
-        subtitles=subtitles,
         target_language=target_lang,
         translation_backend=translation_backend,
     )

--- a/src/koffee/data/config.py
+++ b/src/koffee/data/config.py
@@ -14,8 +14,8 @@ class KoffeeConfig(BaseModel):
     model: str = "large-v3"
     output_dir: Path | None = None
     output_name: str | None = None
+    overlay_video: bool = False
     subtitle_format: str = "vtt"
-    subtitles: bool = False
     target_language: str = "en"
     translation_backend: str = "whisper"
 

--- a/src/koffee/translate.py
+++ b/src/koffee/translate.py
@@ -22,7 +22,7 @@ def translate(
     config: KoffeeConfig | None = None,
     **kwargs: Any,
 ) -> Path | str:
-    """Processes a video file for translation and subtitle overlay."""
+    """Processes a video or audio file for translation and subtitle generation."""
     log.info("Translating file...")
 
     if not Path(video_file_path).exists() or not Path(video_file_path).is_file():
@@ -48,14 +48,12 @@ def translate(
     subtitle_file_path = generate_subtitles(config.subtitle_format, segments)
 
     is_audio = Path(video_file_path).suffix.lower() in AUDIO_EXTENSIONS
-    if is_audio:
-        return _handle_audio_output(
+    if is_audio or not config.overlay_video:
+        return _handle_subtitle_output(
             subtitle_file_path, output_path, config.subtitle_format
         )
 
-    return _finalize_video_output(
-        subtitle_file_path, video_file_path, output_path, config.subtitles
-    )
+    return _finalize_video_output(subtitle_file_path, video_file_path, output_path)
 
 
 def _apply_config_overrides(config: KoffeeConfig | None, kwargs: dict) -> KoffeeConfig:
@@ -69,12 +67,10 @@ def _finalize_video_output(
     subtitle_file_path: Path,
     video_file_path: Path,
     output_path: Path,
-    keep_subtitles: bool,
-) -> Path:
-    """Overlays subtitles onto the video and optionally removes the subtitle file."""
+) -> Path | str:
+    """Overlays subtitles onto the video and removes the subtitle file."""
     output_video = overlay_subtitles(subtitle_file_path, video_file_path, output_path)
-    if not keep_subtitles:
-        subtitle_file_path.unlink()
+    subtitle_file_path.unlink()
     log.info("Finished processing video!")
     return output_video
 
@@ -84,7 +80,7 @@ def _get_output_path(
     output_dir: Path | None,
     output_name: str | None,
 ) -> Path:
-    """Gets the output path for the translated video file."""
+    """Gets the output path for the translated output file."""
     log.debug(f"output_name: {output_name!r}")
 
     file_path = Path(video_file_path)
@@ -111,11 +107,11 @@ def _get_segments(transcript: dict, config: KoffeeConfig) -> list:
     return translate_transcript(transcript, config.target_language, config.api_key)
 
 
-def _handle_audio_output(
+def _handle_subtitle_output(
     subtitle_file_path: Path, output_path: Path, subtitle_format: str
 ) -> Path:
-    """Moves the subtitle file to the output path for audio file inputs."""
+    """Moves the subtitle file to the output path."""
     output_subtitle_path = output_path.with_suffix(f".{subtitle_format}")
     subtitle_file_path.rename(output_subtitle_path)
-    log.info("Finished processing audio file!")
+    log.info("Finished processing file!")
     return output_subtitle_path

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,7 +13,7 @@ from koffee.translate import (
     _finalize_video_output,
     _get_output_path,
     _get_segments,
-    _handle_audio_output,
+    _handle_subtitle_output,
 )
 
 
@@ -25,19 +25,20 @@ def translate_module():
 
 @pytest.mark.integration
 def test_api() -> None:
-    """Tests if the API call successfully outputs a file."""
+    """Tests if the API call successfully outputs a subtitle file."""
     video_file_path = Path("examples/videos/sample_korean_video.mp4")
     output_directory_path = Path("scratch")
     output_file_name = "python_output_video_file"
 
-    output_video_file = koffee.translate(
+    output_file = koffee.translate(
         video_file_path=video_file_path,
         output_dir=output_directory_path,
         output_name=output_file_name,
         compute_type="int8",
     )
 
-    assert Path(output_video_file).exists()
+    assert Path(output_file).exists()
+    assert Path(output_file).suffix in {".srt", ".vtt"}
 
 
 def test_invalid_video_file() -> None:
@@ -99,47 +100,41 @@ def test_get_segments_non_whisper_calls_translate(mocker, translate_module) -> N
     )
 
 
-def test_finalize_video_output_deletes_subtitle_when_not_kept(
+def test_finalize_video_output_deletes_subtitle(
     mocker, tmp_path, translate_module
 ) -> None:
-    """Test that the subtitle file is deleted when keep_subtitles is False."""
+    """Test that the subtitle file is always deleted after overlay."""
     mocker.patch.object(
         translate_module, "overlay_subtitles", return_value=tmp_path / "out.mp4"
     )
     subtitle = tmp_path / "sub.srt"
     subtitle.touch()
 
-    _finalize_video_output(
-        subtitle, tmp_path / "in.mp4", tmp_path / "out.mp4", keep_subtitles=False
-    )
+    _finalize_video_output(subtitle, tmp_path / "in.mp4", tmp_path / "out.mp4")
 
     assert not subtitle.exists()
 
 
-def test_finalize_video_output_keeps_subtitle_when_flagged(
-    mocker, tmp_path, translate_module
-) -> None:
-    """Test that the subtitle file is kept when keep_subtitles is True."""
-    mocker.patch.object(
-        translate_module, "overlay_subtitles", return_value=tmp_path / "out.mp4"
-    )
+def test_handle_subtitle_output_renames_subtitle(tmp_path) -> None:
+    """Test that the subtitle file is moved to the correct output path."""
     subtitle = tmp_path / "sub.srt"
     subtitle.touch()
+    output_path = tmp_path / "track.mp4"
 
-    _finalize_video_output(
-        subtitle, tmp_path / "in.mp4", tmp_path / "out.mp4", keep_subtitles=True
-    )
+    result = _handle_subtitle_output(subtitle, output_path, "srt")
 
-    assert subtitle.exists()
+    assert result == tmp_path / "track.srt"
+    assert result.exists()
+    assert not subtitle.exists()
 
 
-def test_handle_audio_output_renames_subtitle(tmp_path) -> None:
-    """Test that the subtitle file is moved to the correct output path."""
+def test_handle_subtitle_output_audio_renames_subtitle(tmp_path) -> None:
+    """Test that the subtitle file is moved correctly for audio inputs."""
     subtitle = tmp_path / "sub.srt"
     subtitle.touch()
     output_path = tmp_path / "track.mp3"
 
-    result = _handle_audio_output(subtitle, output_path, "srt")
+    result = _handle_subtitle_output(subtitle, output_path, "srt")
 
     assert result == tmp_path / "track.srt"
     assert result.exists()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,8 +44,8 @@ def test_script_run() -> None:
     assert result.returncode == 0
 
 
-def test_subtitles(mocker: MockerFixture) -> None:
-    """Tests if the subtitles flag writes the subtitle file to disk."""
+def test_overlay_video(mocker: MockerFixture) -> None:
+    """Tests that overlay_video flag is passed through to config."""
     mock_translate = mocker.patch("koffee.cli.translate")
 
     cli(
@@ -53,13 +53,30 @@ def test_subtitles(mocker: MockerFixture) -> None:
         compute_type="int8",
         output_dir=output_directory_path,
         output_name=output_file_name,
-        subtitles=True,
+        overlay_video=True,
     )
 
     mock_translate.assert_called_once()
     config = mock_translate.call_args.kwargs["config"]
 
-    assert config.subtitles is True
+    assert config.overlay_video is True
+
+
+def test_overlay_video_defaults_to_false(mocker: MockerFixture) -> None:
+    """Tests that overlay_video defaults to False."""
+    mock_translate = mocker.patch("koffee.cli.translate")
+
+    cli(
+        korean_video_file_path,
+        compute_type="int8",
+        output_dir=output_directory_path,
+        output_name=output_file_name,
+    )
+
+    mock_translate.assert_called_once()
+    config = mock_translate.call_args.kwargs["config"]
+
+    assert config.overlay_video is False
 
 
 def test_verbose(mocker: MockerFixture) -> None:


### PR DESCRIPTION
Currently, video file inputs output a copy of the original file except with the subtitles embed onto it. This is computationally extensive for little to no gain; most modern video plays already automatically pick up subtitle files that are in the same directory as the video file. This refactor changes the behavior of video files to be the same as audio files, i.e., users will only get a translated subtitle file.