### PR TITLE
Add feature to allow users to give a directory of files

### DIFF
--- a/src/koffee/cli.py
+++ b/src/koffee/cli.py
@@ -15,7 +15,7 @@ from rich.progress import (
 )
 
 from koffee.data.config import KoffeeConfig
-from koffee.translate import translate
+from koffee.translate import SUPPORTED_EXTENSIONS, translate
 
 logging.basicConfig(
     level=logging.INFO, format="%(message)s", datefmt="[%X]", handlers=[RichHandler()]
@@ -140,14 +140,24 @@ def cli(
 
 
 def _resolve_paths(file_path: tuple) -> list[Path]:
-    """Resolves glob patterns and returns a flat list of matched paths."""
+    """Resolves glob patterns, directories, and files into a flat list of paths."""
     resolved_paths = []
     for pattern in file_path:
-        matches = sorted(Path.cwd().glob(str(pattern)))
-        if matches:
-            resolved_paths.extend(matches)
+        path = Path(pattern)
+        if path.is_dir():
+            resolved_paths.extend(
+                sorted(
+                    p
+                    for p in path.iterdir()
+                    if p.is_file() and p.suffix.lower() in SUPPORTED_EXTENSIONS
+                )
+            )
         else:
-            resolved_paths.append(Path(pattern))
+            matches = sorted(Path.cwd().glob(str(pattern)))
+            if matches:
+                resolved_paths.extend(matches)
+            else:
+                resolved_paths.append(path)
 
     return resolved_paths
 

--- a/src/koffee/translate.py
+++ b/src/koffee/translate.py
@@ -16,6 +16,8 @@ from koffee.translator import translate_transcript
 log = logging.getLogger(__name__)
 
 AUDIO_EXTENSIONS = {".mp3", ".wav", ".aac", ".flac", ".ogg", ".m4a"}
+VIDEO_EXTENSIONS = {".mp4", ".mkv", ".avi", ".mov", ".webm", ".flv", ".wmv"}
+SUPPORTED_EXTENSIONS = AUDIO_EXTENSIONS | VIDEO_EXTENSIONS
 
 
 def translate(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from pytest_mock import MockerFixture
 
-from koffee.cli import cli
+from koffee.cli import _resolve_paths, cli
 
 korean_video_file_path = Path("examples/videos/sample_korean_video.mp4")
 
@@ -94,3 +94,16 @@ def test_verbose(mocker: MockerFixture) -> None:
     )
 
     logger_instance.setLevel.assert_called_once_with(logging.DEBUG)
+
+
+def test_resolve_paths_expands_directory(tmp_path) -> None:
+    """Tests that a directory input resolves to supported files within it."""
+    (tmp_path / "video.mp4").touch()
+    (tmp_path / "audio.wav").touch()
+    (tmp_path / "readme.txt").touch()
+
+    result = _resolve_paths((tmp_path,))
+
+    suffixes = {p.suffix for p in result}
+    assert suffixes == {".mp4", ".wav"}
+    assert len(result) == 2


### PR DESCRIPTION
Instead of providing concrete files or using wildcards like *.mp3, users can now submit a directory and it will translate all valid files under it