### PR TITLE
Add timeouts to all subprocess calls

### DIFF
--- a/src/koffee/overlay.py
+++ b/src/koffee/overlay.py
@@ -46,7 +46,7 @@ def overlay_subtitles(
     ]
 
     try:
-        subprocess.run(cmd, capture_output=True, text=True, check=True)
+        subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=600)
     except subprocess.CalledProcessError as error:
         raise SubtitleOverlayError(error.stderr) from error
 

--- a/src/koffee/utils/get_video_duration.py
+++ b/src/koffee/utils/get_video_duration.py
@@ -24,6 +24,7 @@ def get_video_duration(video_file_path: Path | str) -> float:
             capture_output=True,
             text=True,
             check=True,
+            timeout=30,
         )
     except FileNotFoundError:
         log.error("ffprobe not found. Please install ffmpeg to use this feature.")

--- a/src/koffee/utils/subtitle_extractor.py
+++ b/src/koffee/utils/subtitle_extractor.py
@@ -27,6 +27,7 @@ def get_subtitle_tracks(video_file_path: Path | str) -> list[dict]:
             capture_output=True,
             text=True,
             check=True,
+            timeout=30,
         )
     except FileNotFoundError:
         log.error("ffprobe not found. Please install ffmpeg to use this feature.")
@@ -56,6 +57,7 @@ def extract_subtitle_track(video_file_path: Path | str, track_index: int = 0) ->
             capture_output=True,
             text=True,
             check=True,
+            timeout=600,
         )
     except subprocess.CalledProcessError as error:
         log.error(f"Failed to extract subtitle track: {error.stderr}")


### PR DESCRIPTION
## Summary
- Adds 30s timeout to ffprobe metadata reads (`get_video_duration`, `get_subtitle_tracks`)
- Adds 600s timeout to ffmpeg processing (`extract_subtitle_track`, `overlay_subtitles`)
- Prevents indefinite hangs on corrupted media files

## Test plan
- [x] `make build` passes (71 tests, 90% coverage)