### PR TITLE
Harden Gemini response parsing

### DIFF
--- a/src/koffee/translator.py
+++ b/src/koffee/translator.py
@@ -160,14 +160,37 @@ def _segments_to_srt(segments: list[dict]) -> str:
     return srt_text
 
 
+def _sanitize_response(response_text: str | None) -> str:
+    """Strips markdown fences and normalizes line endings from LLM output."""
+    if not response_text:
+        return ""
+
+    text = response_text.replace("\r\n", "\n").strip()
+
+    if text.startswith("```"):
+        first_newline = text.find("\n")
+        if first_newline != -1:
+            text = text[first_newline + 1 :]
+        if text.endswith("```"):
+            text = text[:-3]
+        text = text.strip()
+
+    return text
+
+
 def _parse_srt_response(
-    response_text: str, original_segments: list[dict]
+    response_text: str | None, original_segments: list[dict]
 ) -> list[dict]:
     """Parses SRT formatted response back into segments."""
     MIN_SRT_BLOCK_LINES = 3
 
+    sanitized = _sanitize_response(response_text)
+    if not sanitized:
+        log.warning("Empty Gemini response, using original segments.")
+        return list(original_segments)
+
     translated_segments = []
-    blocks = response_text.strip().split("\n\n")
+    blocks = [b.strip() for b in sanitized.split("\n\n") if b.strip()]
 
     if len(blocks) < len(original_segments):
         log.warning(
@@ -177,7 +200,7 @@ def _parse_srt_response(
         )
 
     for block, original in zip(blocks, original_segments, strict=False):
-        lines = block.strip().split("\n")
+        lines = block.split("\n")
         if len(lines) < MIN_SRT_BLOCK_LINES:
             log.warning("Unexpected SRT block format, using original text.")
             translated_segments.append(original)

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -5,6 +5,7 @@ from pytest_mock import MockerFixture
 from koffee.translator import (
     _build_prompt,
     _parse_srt_response,
+    _sanitize_response,
     translate_transcript,
 )
 
@@ -136,6 +137,60 @@ def test_translate_transcript_passes_api_key(mocker: MockerFixture) -> None:
     translate_transcript(SAMPLE_TRANSCRIPT, "en", api_key="test-key")
 
     mock_client_cls.assert_called_once_with(api_key="test-key")
+
+
+def test_sanitize_response_strips_markdown_fences() -> None:
+    """Tests that markdown code fences are stripped from the response."""
+    wrapped = "```srt\n1\n00:00:00,000 --> 00:00:01,000\nHello.\n```"
+    result = _sanitize_response(wrapped)
+    assert not result.startswith("```")
+    assert not result.endswith("```")
+    assert "Hello." in result
+
+
+def test_sanitize_response_normalizes_crlf() -> None:
+    """Tests that CRLF line endings are normalized to LF."""
+    crlf_text = "1\r\n00:00:00,000 --> 00:00:01,000\r\nHello."
+    result = _sanitize_response(crlf_text)
+    assert "\r" not in result
+
+
+def test_sanitize_response_returns_empty_for_none() -> None:
+    """Tests that None input returns an empty string."""
+    assert _sanitize_response(None) == ""
+    assert _sanitize_response("") == ""
+
+
+def test_parse_srt_response_empty_returns_originals() -> None:
+    """Tests that an empty response falls back to original segments."""
+    result = _parse_srt_response("", SAMPLE_SEGMENTS)
+    assert result == SAMPLE_SEGMENTS
+
+
+def test_parse_srt_response_none_returns_originals() -> None:
+    """Tests that a None response falls back to original segments."""
+    result = _parse_srt_response(None, SAMPLE_SEGMENTS)
+    assert result == SAMPLE_SEGMENTS
+
+
+def test_parse_srt_response_extra_blank_lines() -> None:
+    """Tests that extra blank lines in the response are filtered out."""
+    response_with_extra_blanks = (
+        "\n\n1\n00:00:00,000 --> 00:00:06,360\nHello.\n\n\n\n"
+        "2\n00:00:07,800 --> 00:00:10,740\nHow have you been?\n\n"
+    )
+    result = _parse_srt_response(response_with_extra_blanks, SAMPLE_SEGMENTS)
+    assert len(result) == 2
+    assert result[0]["text"] == "Hello."
+    assert result[1]["text"] == "How have you been?"
+
+
+def test_parse_srt_response_markdown_fenced() -> None:
+    """Tests that a markdown-fenced SRT response is parsed correctly."""
+    fenced = "```srt\n" + SAMPLE_SRT_RESPONSE + "\n```"
+    result = _parse_srt_response(fenced, SAMPLE_SEGMENTS)
+    assert len(result) == 2
+    assert result[0]["text"] == "Hello."
 
 
 def test_translate_transcript_reports_progress(mocker: MockerFixture) -> None:


### PR DESCRIPTION
## Summary
- Adds `_sanitize_response()` that strips markdown code fences, normalizes CRLF, and handles None/empty input
- `_parse_srt_response()` now filters empty blocks from extra blank lines and falls back gracefully on empty responses
- 7 new tests covering markdown fences, CRLF, None/empty input, and extra blank lines

## Test plan
- [x] `make build` passes (78 tests, 90% coverage)