### PR TITLE
Add config file support via koffee.toml

### DIFF
--- a/src/koffee/cli.py
+++ b/src/koffee/cli.py
@@ -14,7 +14,7 @@ from rich.progress import (
     TimeElapsedColumn,
 )
 
-from koffee.data.config import KoffeeConfig
+from koffee.data.config import KoffeeConfig, load_config_file
 from koffee.translate import SUBTITLE_EXTENSIONS, SUPPORTED_EXTENSIONS, translate
 from koffee.utils import get_subtitle_tracks
 
@@ -36,7 +36,7 @@ options_group = Group("Options", sort_key=2)
 app["--help"].group = options_group
 app["--version"].group = options_group
 
-options = KoffeeConfig()
+options = KoffeeConfig(**load_config_file())
 
 
 def _create_progress_bar() -> Progress:

--- a/src/koffee/data/config.py
+++ b/src/koffee/data/config.py
@@ -1,9 +1,19 @@
 """The koffee Configuration."""
 
+import logging
 from pathlib import Path
 from typing import Literal
 
+import tomllib
 from pydantic import BaseModel, ConfigDict
+
+log = logging.getLogger(__name__)
+
+CONFIG_FILENAME = "koffee.toml"
+CONFIG_SEARCH_PATHS = [
+    Path.cwd() / CONFIG_FILENAME,
+    Path.home() / ".config" / "koffee" / CONFIG_FILENAME,
+]
 
 
 class KoffeeConfig(BaseModel):
@@ -26,3 +36,19 @@ class KoffeeConfig(BaseModel):
     dry_run: bool = False
     overwrite: bool = False
     use_embedded_subtitles: bool = False
+
+
+def load_config_file(path: Path | None = None) -> dict:
+    """Loads config from a TOML file, searching default paths if none given.
+
+    Returns an empty dict if no config file is found.
+    """
+    search_paths = [path] if path is not None else CONFIG_SEARCH_PATHS
+
+    for config_path in search_paths:
+        if config_path.is_file():
+            log.debug(f"Loading config from {config_path}")
+            with config_path.open("rb") as f:
+                return tomllib.load(f)
+
+    return {}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,51 @@
+"""Tests for config file loading."""
+
+from koffee.data.config import KoffeeConfig, load_config_file
+
+
+def test_load_config_file_returns_empty_when_not_found(tmp_path) -> None:
+    """Tests that an empty dict is returned when no config file exists."""
+    result = load_config_file(tmp_path / "nonexistent.toml")
+    assert result == {}
+
+
+def test_load_config_file_reads_toml(tmp_path) -> None:
+    """Tests that a valid TOML file is parsed correctly."""
+    config_path = tmp_path / "koffee.toml"
+    config_path.write_text('source_language = "ko"\nsubtitle_format = "srt"\n')
+
+    result = load_config_file(config_path)
+
+    assert result["source_language"] == "ko"
+    assert result["subtitle_format"] == "srt"
+
+
+def test_load_config_file_searches_default_paths(tmp_path, monkeypatch) -> None:
+    """Tests that load_config_file searches cwd for koffee.toml."""
+    config_path = tmp_path / "koffee.toml"
+    config_path.write_text('target_language = "fr"\n')
+    monkeypatch.setattr("koffee.data.config.CONFIG_SEARCH_PATHS", [config_path])
+
+    result = load_config_file()
+
+    assert result["target_language"] == "fr"
+
+
+def test_config_file_values_apply_to_koffee_config(tmp_path) -> None:
+    """Tests that config file values override KoffeeConfig defaults."""
+    config_path = tmp_path / "koffee.toml"
+    config_path.write_text(
+        'source_language = "ko"\n'
+        'subtitle_format = "srt"\n'
+        'translation_backend = "gemini"\n'
+    )
+
+    file_config = load_config_file(config_path)
+    config = KoffeeConfig(**file_config)
+
+    assert config.source_language == "ko"
+    assert config.subtitle_format == "srt"
+    assert config.translation_backend == "gemini"
+    # Defaults should still apply for unset fields
+    assert config.target_language == "en"
+    assert config.device == "auto"


### PR DESCRIPTION
## Summary
- Adds `load_config_file()` that searches `./koffee.toml` then `~/.config/koffee/koffee.toml`
- Config file values serve as CLI defaults; CLI args override them
- Uses stdlib `tomllib` (requires Python 3.11+, 3.10 deprecation coming next)

## Test plan
- [x] `make build` passes (82 tests, 90% coverage)
- [x] 100% coverage on `config.py`