### PR TITLE
Drop Python 3.10 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - name: Check out repository

--- a/noxfile.py
+++ b/noxfile.py
@@ -4,7 +4,7 @@ import nox
 from nox.sessions import Session
 
 
-@nox.session(python=["3.10", "3.11", "3.12", "3.13"])
+@nox.session(python=["3.11", "3.12", "3.13"])
 def test_build_from_wheel(session: Session) -> None:
     """Runs tests with local installation from a built wheel."""
     session.install("pytest")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "Kim, Andrew", email = "andrewkimka@gmail.com"}
 ]
 readme = "README.md"
-requires-python = ">=3.10, <3.14"
+requires-python = ">=3.11, <3.14"
 dependencies = [
     "faster-whisper>=1.0.3",
     "torch>=2.2.2",
@@ -49,7 +49,7 @@ testpaths = ["tests"]
 include = ["src"]
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py311"
 line-length = 88
 fix = true
 unsafe-fixes = true

--- a/src/koffee/data/config.py
+++ b/src/koffee/data/config.py
@@ -1,10 +1,10 @@
 """The koffee Configuration."""
 
 import logging
+import tomllib
 from pathlib import Path
 from typing import Literal
 
-import tomllib
 from pydantic import BaseModel, ConfigDict
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- Minimum Python version is now 3.11
- Removes 3.10 from CI matrix (12 → 9 jobs), nox sessions, and pyproject.toml
- Bumps ruff target-version to py311
- Enables stdlib `tomllib` import without backport

## Test plan
- [x] `make build` passes (82 tests, 90% coverage)