### PR TITLE
Add subtitle track selection and source language auto-detection

### DIFF
--- a/src/koffee/cli.py
+++ b/src/koffee/cli.py
@@ -200,10 +200,39 @@ def _check_embedded_subtitles(video: Path, config: KoffeeConfig) -> KoffeeConfig
     log.info(f"Found {track_count} embedded subtitle track(s) in {video.name}.")
 
     response = input("Translate embedded subtitles instead of running ASR? [Y/n] ")
-    if response.strip().lower() in ("", "y", "yes"):
-        return config.model_copy(update={"use_embedded_subtitles": True})
+    if response.strip().lower() not in ("", "y", "yes"):
+        return config
 
-    return config
+    track_index, source_language = _select_subtitle_track(tracks)
+    updates = {"use_embedded_subtitles": True, "subtitle_track_index": track_index}
+    if source_language:
+        updates["source_language"] = source_language
+
+    return config.model_copy(update=updates)
+
+
+def _select_subtitle_track(tracks: list[dict]) -> tuple[int, str | None]:
+    """Prompts user to select a subtitle track if multiple are available."""
+    if len(tracks) == 1:
+        language = tracks[0].get("tags", {}).get("language")
+        return 0, language
+
+    log.info("Available subtitle tracks:")
+    for i, track in enumerate(tracks):
+        tags = track.get("tags", {})
+        lang = tags.get("language", "unknown")
+        title = tags.get("title", "")
+        label = f"  [{i}] {lang}"
+        if title:
+            label += f" — {title}"
+        log.info(label)
+
+    response = input(f"Select track [0-{len(tracks) - 1}] (default 0): ")
+    index = int(response.strip()) if response.strip().isdigit() else 0
+    index = max(0, min(index, len(tracks) - 1))
+
+    language = tracks[index].get("tags", {}).get("language")
+    return index, language
 
 
 def _resolve_paths(file_path: tuple) -> list[Path]:

--- a/src/koffee/data/config.py
+++ b/src/koffee/data/config.py
@@ -28,13 +28,14 @@ class KoffeeConfig(BaseModel):
     output_dir: Path | None = None
     output_name: str | None = None
     overlay_video: bool = False
-    source_language: str = "ja"
+    source_language: str = "auto"
     subtitle_format: Literal["srt", "vtt", "ass"] = "vtt"
     target_language: str = "en"
     translation_backend: Literal["whisper", "gemini"] = "whisper"
     translation_model: str = "gemini-2.5-flash"
     dry_run: bool = False
     overwrite: bool = False
+    subtitle_track_index: int = 0
     use_embedded_subtitles: bool = False
 
 

--- a/src/koffee/translate.py
+++ b/src/koffee/translate.py
@@ -152,7 +152,9 @@ def _translate_embedded_subtitles(
     """Extracts embedded subtitles from a video and translates them."""
     log.info("Extracting embedded subtitles from video.")
 
-    extracted_path = extract_subtitle_track(video_file_path)
+    extracted_path = extract_subtitle_track(
+        video_file_path, config.subtitle_track_index
+    )
     try:
         result = _translate_subtitle_file(extracted_path, config, on_progress)
     finally:

--- a/src/koffee/translator.py
+++ b/src/koffee/translator.py
@@ -226,12 +226,15 @@ def _build_prompt(
     start_entry: int,
 ) -> str:
     """Builds the translation prompt for a chunk of subtitle entries."""
-    prompt_parts = [
-        (
+    if source_language == "auto":
+        instruction = f"Translate the following subtitle entries to {target_language}."
+    else:
+        instruction = (
             f"Translate the following subtitle entries from "
             f"{source_language} to {target_language}."
         )
-    ]
+
+    prompt_parts = [instruction]
 
     if context_entries:
         prompt_parts.extend(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,12 @@ from pathlib import Path
 
 from pytest_mock import MockerFixture
 
-from koffee.cli import _check_embedded_subtitles, _resolve_paths, cli
+from koffee.cli import (
+    _check_embedded_subtitles,
+    _resolve_paths,
+    _select_subtitle_track,
+    cli,
+)
 from koffee.data.config import KoffeeConfig
 
 korean_video_file_path = Path("examples/videos/sample_korean_video.mp4")
@@ -199,16 +204,15 @@ def test_check_embedded_subtitles_user_accepts(
     mocker: MockerFixture,
 ) -> None:
     """Tests that accepting embedded subtitles updates config."""
-    mocker.patch(
-        "koffee.cli.get_subtitle_tracks",
-        return_value=[{"index": 0, "codec": "srt"}],
-    )
+    tracks = [{"index": 0, "codec": "srt", "tags": {"language": "ko"}}]
+    mocker.patch("koffee.cli.get_subtitle_tracks", return_value=tracks)
     mocker.patch("builtins.input", return_value="y")
     config = KoffeeConfig()
 
     result = _check_embedded_subtitles(korean_video_file_path, config)
 
     assert result.use_embedded_subtitles is True
+    assert result.source_language == "ko"
 
 
 def test_check_embedded_subtitles_user_declines(
@@ -258,3 +262,51 @@ def test_batch_progress_logging(mocker: MockerFixture) -> None:
     log_messages = [call.args[0] for call in mock_log.info.call_args_list]
     assert any("[1/2]" in msg for msg in log_messages)
     assert any("[2/2]" in msg for msg in log_messages)
+
+
+def test_select_subtitle_track_single() -> None:
+    """Tests that a single track is selected automatically."""
+    tracks = [{"index": 0, "tags": {"language": "ja"}}]
+
+    index, lang = _select_subtitle_track(tracks)
+
+    assert index == 0
+    assert lang == "ja"
+
+
+def test_select_subtitle_track_multiple(mocker: MockerFixture) -> None:
+    """Tests that user can select from multiple tracks."""
+    tracks = [
+        {"index": 0, "tags": {"language": "ja", "title": "Japanese"}},
+        {"index": 1, "tags": {"language": "ko", "title": "Korean"}},
+    ]
+    mocker.patch("builtins.input", return_value="1")
+
+    index, lang = _select_subtitle_track(tracks)
+
+    assert index == 1
+    assert lang == "ko"
+
+
+def test_select_subtitle_track_default_on_empty_input(mocker: MockerFixture) -> None:
+    """Tests that empty input defaults to track 0."""
+    tracks = [
+        {"index": 0, "tags": {"language": "ja"}},
+        {"index": 1, "tags": {"language": "ko"}},
+    ]
+    mocker.patch("builtins.input", return_value="")
+
+    index, lang = _select_subtitle_track(tracks)
+
+    assert index == 0
+    assert lang == "ja"
+
+
+def test_select_subtitle_track_missing_language_tag() -> None:
+    """Tests that a track without language tag returns None."""
+    tracks = [{"index": 0, "tags": {}}]
+
+    index, lang = _select_subtitle_track(tracks)
+
+    assert index == 0
+    assert lang is None

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -44,6 +44,20 @@ def test_build_prompt_with_context() -> None:
     assert "안녕하세요." in result
 
 
+def test_build_prompt_auto_source_language() -> None:
+    """Tests that 'auto' source language omits the source from the prompt."""
+    result = _build_prompt(
+        chunk=SAMPLE_SEGMENTS,
+        context_entries=[],
+        source_language="auto",
+        target_language="en",
+        start_entry=1,
+    )
+
+    assert "Translate the following subtitle entries to en." in result
+    assert "from" not in result.split("\n")[0]
+
+
 def test_build_prompt_without_context() -> None:
     """Tests that the prompt omits context section when no context entries are given."""
     result = _build_prompt(


### PR DESCRIPTION
## Summary
- Embedded subtitle track selection: shows tracks with language tags, lets user pick when multiple exist
- Source language defaults to `auto` instead of `ja` — Whisper/Gemini detect it
- Selected track's language metadata propagates to config for Gemini translation prompts
- New `subtitle_track_index` config field for track selection

## Test plan
- [x] `make build` passes (87 tests, 91% coverage)
- [x] 5 new tests for track selection and auto language prompt