### PR TITLE
Replace --overlay-video with --overlay none/soft/hard

### DIFF
--- a/src/koffee/cli.py
+++ b/src/koffee/cli.py
@@ -78,9 +78,9 @@ def cli(
     subtitle_format: Annotated[
         str, Parameter(name=("--subtitle_format", "-sf"))
     ] = options.subtitle_format,
-    overlay_video: Annotated[
-        bool, Parameter(name=("--overlay-video",), group=options_group)
-    ] = options.overlay_video,
+    overlay: Annotated[
+        str, Parameter(name=("--overlay",), group=options_group)
+    ] = options.overlay,
     translation_backend: Annotated[
         str, Parameter(name=("--translation_backend", "-tb"))
     ] = options.translation_backend,
@@ -114,11 +114,11 @@ def cli(
         Name of the output file
     subtitle_format: str
         Format to use for the subtitles
-    overlay_video: bool
-        Embed subtitles into the video as a soft subtitle track instead of
-        outputting a subtitle file. Only valid for video file inputs.
+    overlay: str
+        Subtitle overlay mode: none (subtitle file only), soft (muxed track),
+        or hard (burned into video frames). Only valid for video file inputs.
     source_language: str
-        Source language of the subtitle file (default: ja)
+        Source language of the subtitle file (default: auto)
     target_language: str
         Language to which the file should be translated
     translation_backend: str
@@ -144,7 +144,7 @@ def cli(
         overwrite=overwrite,
         output_dir=output_dir,
         output_name=output_name,
-        overlay_video=overlay_video,
+        overlay=overlay,
         source_language=source_lang,
         subtitle_format=subtitle_format,
         target_language=target_lang,
@@ -183,8 +183,8 @@ def _print_dry_run(resolved_paths: list[Path], config: KoffeeConfig) -> None:
 
     log.info(f"[dry-run] Target language: {config.target_language}")
     log.info(f"[dry-run] Output format: {config.subtitle_format}")
-    if config.overlay_video:
-        log.info("[dry-run] Subtitles will be embedded into video")
+    if config.overlay != "none":
+        log.info(f"[dry-run] Subtitles will be embedded into video ({config.overlay})")
 
 
 def _check_embedded_subtitles(video: Path, config: KoffeeConfig) -> KoffeeConfig:

--- a/src/koffee/data/config.py
+++ b/src/koffee/data/config.py
@@ -27,7 +27,7 @@ class KoffeeConfig(BaseModel):
     model: str = "large-v3"
     output_dir: Path | None = None
     output_name: str | None = None
-    overlay_video: bool = False
+    overlay: Literal["none", "soft", "hard"] = "none"
     source_language: str = "auto"
     subtitle_format: Literal["srt", "vtt", "ass"] = "vtt"
     target_language: str = "en"

--- a/src/koffee/overlay.py
+++ b/src/koffee/overlay.py
@@ -23,9 +23,28 @@ def overlay_subtitles(
     subtitle_file_path: Path | str,
     video_file_path: Path | str,
     output_file_path: Path | str,
+    mode: str = "soft",
 ) -> Path | str:
-    """Overlay subtitles to a video file."""
-    log.info("Overlaying subtitles.")
+    """Overlay subtitles to a video file.
+
+    Args:
+        subtitle_file_path: Path to the subtitle file.
+        video_file_path: Path to the source video file.
+        output_file_path: Path for the output video file.
+        mode: "soft" for muxed subtitle track, "hard" for burned-in subtitles.
+    """
+    if mode == "hard":
+        return _burn_in_subtitles(subtitle_file_path, video_file_path, output_file_path)
+    return _mux_subtitles(subtitle_file_path, video_file_path, output_file_path)
+
+
+def _mux_subtitles(
+    subtitle_file_path: Path | str,
+    video_file_path: Path | str,
+    output_file_path: Path | str,
+) -> Path | str:
+    """Muxes subtitles as a soft track (original behavior)."""
+    log.info("Overlaying subtitles (soft).")
 
     subtitle_codec = _get_subtitle_codec(output_file_path)
 
@@ -41,6 +60,36 @@ def overlay_subtitles(
         subtitle_codec,
         "-metadata:s:s:0",
         "language=eng",
+        "-y",
+        str(output_file_path),
+    ]
+
+    try:
+        subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=600)
+    except subprocess.CalledProcessError as error:
+        raise SubtitleOverlayError(error.stderr) from error
+
+    return output_file_path
+
+
+def _burn_in_subtitles(
+    subtitle_file_path: Path | str,
+    video_file_path: Path | str,
+    output_file_path: Path | str,
+) -> Path | str:
+    """Burns subtitles into the video frames (hard subtitles)."""
+    log.info("Burning in subtitles (hard).")
+
+    escaped_path = str(subtitle_file_path).replace("\\", "\\\\").replace(":", "\\:")
+
+    cmd = [
+        "ffmpeg",
+        "-i",
+        str(video_file_path),
+        "-vf",
+        f"subtitles={escaped_path}",
+        "-c:a",
+        "copy",
         "-y",
         str(output_file_path),
     ]

--- a/src/koffee/translate.py
+++ b/src/koffee/translate.py
@@ -129,7 +129,7 @@ def _route_output(
     )
     is_audio = Path(video_file_path).suffix.lower() in AUDIO_EXTENSIONS
 
-    if is_audio or not config.overlay_video:
+    if is_audio or config.overlay == "none":
         target = output_path.with_suffix(f".{config.subtitle_format}")
         _check_output_collision(target, config.overwrite)
         output_file_path = _handle_subtitle_output(
@@ -138,7 +138,7 @@ def _route_output(
     else:
         _check_output_collision(output_path, config.overwrite)
         output_file_path = _finalize_video_output(
-            subtitle_file_path, video_file_path, output_path
+            subtitle_file_path, video_file_path, output_path, config.overlay
         )
 
     return output_file_path
@@ -235,9 +235,12 @@ def _finalize_video_output(
     subtitle_file_path: Path,
     video_file_path: Path,
     output_path: Path,
+    overlay_mode: str = "soft",
 ) -> Path:
-    """Embeds subtitles into the video as a soft subtitle track and deletes it after."""
-    output_video = overlay_subtitles(subtitle_file_path, video_file_path, output_path)
+    """Embeds subtitles into the video and deletes the subtitle file after."""
+    output_video = overlay_subtitles(
+        subtitle_file_path, video_file_path, output_path, mode=overlay_mode
+    )
     subtitle_file_path.unlink()
     log.info("Finished processing video!")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,8 +50,8 @@ def test_script_run() -> None:
     assert result.returncode == 0
 
 
-def test_overlay_video(mocker: MockerFixture) -> None:
-    """Tests that overlay_video flag is passed through to config."""
+def test_overlay_soft(mocker: MockerFixture) -> None:
+    """Tests that overlay flag is passed through to config."""
     mock_translate = mocker.patch("koffee.cli.translate")
 
     cli(
@@ -59,17 +59,17 @@ def test_overlay_video(mocker: MockerFixture) -> None:
         compute_type="int8",
         output_dir=output_directory_path,
         output_name=output_file_name,
-        overlay_video=True,
+        overlay="soft",
     )
 
     mock_translate.assert_called_once()
     config = mock_translate.call_args.kwargs["config"]
 
-    assert config.overlay_video is True
+    assert config.overlay == "soft"
 
 
-def test_overlay_video_defaults_to_false(mocker: MockerFixture) -> None:
-    """Tests that overlay_video defaults to False."""
+def test_overlay_defaults_to_none(mocker: MockerFixture) -> None:
+    """Tests that overlay defaults to none."""
     mock_translate = mocker.patch("koffee.cli.translate")
 
     cli(
@@ -82,7 +82,7 @@ def test_overlay_video_defaults_to_false(mocker: MockerFixture) -> None:
     mock_translate.assert_called_once()
     config = mock_translate.call_args.kwargs["config"]
 
-    assert config.overlay_video is False
+    assert config.overlay == "none"
 
 
 def test_verbose(mocker: MockerFixture) -> None:
@@ -171,7 +171,7 @@ def test_dry_run_with_overlay(mocker: MockerFixture) -> None:
         korean_video_file_path,
         output_dir=output_directory_path,
         dry_run=True,
-        overlay_video=True,
+        overlay="soft",
     )
 
 

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -37,6 +37,17 @@ def test_overlay(
     assert output_file_path.exists()
 
 
+def test_hard_overlay(
+    video_file_path: Path, subtitle_file_path: Path, output_file_path: Path
+) -> None:
+    """Tests that hard burn-in produces an output file."""
+    overlay_subtitles(
+        subtitle_file_path, video_file_path, output_file_path, mode="hard"
+    )
+
+    assert output_file_path.exists()
+
+
 def test_exception_handling(
     subtitle_file_path: Path,
     video_file_path: Path,


### PR DESCRIPTION
## Summary
- Replaces boolean `--overlay-video` with `--overlay none|soft|hard`
- `soft`: muxed subtitle track (original behavior)
- `hard`: burns subtitles into video frames via `ffmpeg -vf subtitles=...`
- `none`: subtitle file only (default)

## Test plan
- [x] `make build` passes (88 tests, 91% coverage)
- [x] Hard burn-in tested with real ffmpeg against sample video