### PR TITLE
Strip leading whitespace from subtitle text output

### DIFF
--- a/src/koffee/utils/ass_converter.py
+++ b/src/koffee/utils/ass_converter.py
@@ -51,7 +51,7 @@ def convert_text_to_ass(transcript: list, output_dir: Path) -> Path:
         for subtitle in transcript:
             start = _seconds_to_ass_timestamp(subtitle["start"])
             end = _seconds_to_ass_timestamp(subtitle["end"])
-            text = subtitle["text"].replace("\n", "\\N")
+            text = subtitle["text"].strip().replace("\n", "\\N")
             file.write(f"Dialogue: 0,{start},{end},Default,,0,0,0,,{text}\n")
 
     log.debug(repr(output_file_path))

--- a/src/koffee/utils/srt_converter.py
+++ b/src/koffee/utils/srt_converter.py
@@ -20,7 +20,7 @@ def convert_text_to_srt(transcript: list, output_dir: Path) -> Path:
         for idx, subtitle in enumerate(transcript, 1):
             start = convert_to_timestamp(subtitle["start"], "srt")
             end = convert_to_timestamp(subtitle["end"], "srt")
-            text = subtitle["text"]
+            text = subtitle["text"].strip()
 
             file.write(f"{idx}\n")
             file.write(f"{start} --> {end}\n")

--- a/src/koffee/utils/vtt_converter.py
+++ b/src/koffee/utils/vtt_converter.py
@@ -22,7 +22,7 @@ def convert_text_to_vtt(transcript: list, output_dir: Path) -> Path:
         for idx, subtitle in enumerate(transcript, 1):
             start = convert_to_timestamp(subtitle["start"], "vtt")
             end = convert_to_timestamp(subtitle["end"], "vtt")
-            text = subtitle["text"]
+            text = subtitle["text"].strip()
 
             file.write(f"{start} --> {end}\n")
             if idx != len(transcript):


### PR DESCRIPTION
## Summary
- Whisper pads segment text with a leading space (e.g., `" My son."`)
- Adds `.strip()` in SRT, VTT, and ASS converters before writing text

## Test plan
- [x] `make build` passes (88 tests, 91% coverage)