### PR TITLE
Add info and tracks subcommands

### DIFF
--- a/src/koffee/cli.py
+++ b/src/koffee/cli.py
@@ -1,6 +1,8 @@
 """The koffee CLI."""
 
 import logging
+import shutil
+import subprocess
 from pathlib import Path
 from typing import Annotated
 
@@ -14,7 +16,7 @@ from rich.progress import (
     TimeElapsedColumn,
 )
 
-from koffee.data.config import KoffeeConfig, load_config_file
+from koffee.data.config import CONFIG_SEARCH_PATHS, KoffeeConfig, load_config_file
 from koffee.translate import SUBTITLE_EXTENSIONS, SUPPORTED_EXTENSIONS, translate
 from koffee.utils import get_subtitle_tracks
 
@@ -293,6 +295,75 @@ def _translate_with_progress(
             on_asr_progress=on_asr_progress,
             on_translate_progress=_make_progress_callback(progress, translate_task),
         )
+
+
+@app.command()
+def info() -> None:
+    """Display system information for debugging."""
+    log.info("[koffee info]")
+
+    ffmpeg_path = shutil.which("ffmpeg")
+    if ffmpeg_path:
+        result = subprocess.run(
+            ["ffmpeg", "-version"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        version_line = result.stdout.split("\n")[0]
+        log.info(f"  ffmpeg: {version_line}")
+    else:
+        log.info("  ffmpeg: not found")
+
+    ffprobe_path = shutil.which("ffprobe")
+    log.info(f"  ffprobe: {'found' if ffprobe_path else 'not found'}")
+
+    try:
+        import torch  # noqa: PLC0415
+
+        cuda_available = torch.cuda.is_available()
+        device_name = torch.cuda.get_device_name(0) if cuda_available else "N/A"
+        log.info(f"  CUDA: {'available' if cuda_available else 'not available'}")
+        if cuda_available:
+            log.info(f"  GPU: {device_name}")
+    except ImportError:
+        log.info("  torch: not installed")
+
+    config = KoffeeConfig(**load_config_file())
+    log.info(f"  default model: {config.model}")
+    log.info(f"  default backend: {config.translation_backend}")
+    log.info(f"  config file: {_find_config_path() or 'none'}")
+
+
+def _find_config_path() -> Path | None:
+    """Returns the path to the active config file, or None."""
+    for path in CONFIG_SEARCH_PATHS:
+        if path.is_file():
+            return path
+    return None
+
+
+@app.command()
+def tracks(
+    file_path: Annotated[Path, Parameter(validator=validators.Path(exists=True))],
+) -> None:
+    """List embedded subtitle tracks in a video file."""
+    track_list = get_subtitle_tracks(file_path)
+
+    if not track_list:
+        log.info(f"No subtitle tracks found in {file_path.name}.")
+        return
+
+    log.info(f"Subtitle tracks in {file_path.name}:")
+    for i, track in enumerate(track_list):
+        tags = track.get("tags", {})
+        lang = tags.get("language", "unknown")
+        title = tags.get("title", "")
+        label = f"  [{i}] {lang}"
+        if title:
+            label += f" — {title}"
+        log.info(label)
 
 
 def main() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,9 +9,12 @@ from pytest_mock import MockerFixture
 
 from koffee.cli import (
     _check_embedded_subtitles,
+    _find_config_path,
     _resolve_paths,
     _select_subtitle_track,
     cli,
+    info,
+    tracks,
 )
 from koffee.data.config import KoffeeConfig
 
@@ -304,9 +307,59 @@ def test_select_subtitle_track_default_on_empty_input(mocker: MockerFixture) -> 
 
 def test_select_subtitle_track_missing_language_tag() -> None:
     """Tests that a track without language tag returns None."""
-    tracks = [{"index": 0, "tags": {}}]
+    track_list = [{"index": 0, "tags": {}}]
 
-    index, lang = _select_subtitle_track(tracks)
+    index, lang = _select_subtitle_track(track_list)
 
     assert index == 0
     assert lang is None
+
+
+def test_info_command(mocker: MockerFixture) -> None:
+    """Tests that info command runs without error."""
+    mocker.patch("koffee.cli.shutil.which", return_value="/usr/bin/ffmpeg")
+    mocker.patch(
+        "koffee.cli.subprocess.run",
+        return_value=subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="ffmpeg version 7.0\n"
+        ),
+    )
+
+    info()
+
+
+def test_info_command_no_ffmpeg(mocker: MockerFixture) -> None:
+    """Tests that info command handles missing ffmpeg."""
+    mocker.patch("koffee.cli.shutil.which", return_value=None)
+
+    info()
+
+
+def test_tracks_command(mocker: MockerFixture) -> None:
+    """Tests that tracks command lists subtitle tracks."""
+    mocker.patch(
+        "koffee.cli.get_subtitle_tracks",
+        return_value=[
+            {"index": 0, "tags": {"language": "ja", "title": "Japanese"}},
+            {"index": 1, "tags": {"language": "en"}},
+        ],
+    )
+
+    tracks(korean_video_file_path)
+
+
+def test_tracks_command_no_tracks(mocker: MockerFixture) -> None:
+    """Tests that tracks command handles no subtitle tracks."""
+    mocker.patch("koffee.cli.get_subtitle_tracks", return_value=[])
+
+    tracks(korean_video_file_path)
+
+
+def test_find_config_path_returns_none(monkeypatch) -> None:
+    """Tests that _find_config_path returns None when no config exists."""
+    monkeypatch.setattr(
+        "koffee.cli.CONFIG_SEARCH_PATHS",
+        [Path("/nonexistent/koffee.toml")],
+    )
+
+    assert _find_config_path() is None


### PR DESCRIPTION
## Summary
- `koffee info`: shows ffmpeg/ffprobe status, CUDA/GPU info, default model/backend, active config file
- `koffee tracks <file>`: lists embedded subtitle tracks with index, language, and title

## Test plan
- [x] `make build` passes (107 tests, 97% coverage)
- [x] Both commands verified manually