### PR TITLE
Polish for 0.1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,35 @@ Refer below for a list of all arguments, commands, parameters, and options.
     --overlay                   Subtitle overlay mode: none, soft, or hard.
     --overwrite                 Overwrite existing output files.
 
+## Configuration
+
+koffee can be configured with a `koffee.toml` file. It searches for the file in the following locations (in order):
+
+1. Current working directory: `./koffee.toml`
+2. User config directory: `~/.config/koffee/koffee.toml`
+
+Settings follow this precedence: **defaults < config file < CLI arguments**.
+
+Example `koffee.toml`:
+
+```toml
+source_language = "ko"
+target_language = "en"
+subtitle_format = "srt"
+translation_backend = "gemini"
+model = "large-v3"
+device = "cuda"
+compute_type = "float16"
+```
+
+### Compute types
+
+Valid values for `--compute-type`: `default`, `auto`, `int8`, `int8_float16`, `int8_float32`, `int8_bfloat16`, `int16`, `float16`, `bfloat16`, `float32`.
+
+### API key
+
+When using the Gemini translation backend, an API key can be provided via `--api_key` or the `GOOGLE_API_KEY` environment variable.
+
 ## Contributing
 
 The simplest way to start developing is by using either a [DevContainer](https://code.visualstudio.com/docs/devcontainers/containers) or [uv](https://docs.astral.sh/uv/).

--- a/features/exceptions.feature
+++ b/features/exceptions.feature
@@ -8,4 +8,4 @@ Feature: koffee Exceptions
 
     Examples: message
         | message                                                    |
-        | Inputted file is not valid or does not exist. |
+        | Input file is not valid or does not exist. |

--- a/src/koffee/data/config.py
+++ b/src/koffee/data/config.py
@@ -1,13 +1,19 @@
 """The koffee Configuration."""
 
 import logging
+import os
 import tomllib
 from pathlib import Path
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict
+from faster_whisper import available_models
+from faster_whisper.tokenizer import _LANGUAGE_CODES
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
 log = logging.getLogger(__name__)
+
+WHISPER_MODELS = set(available_models())
+LANGUAGE_CODES = set(_LANGUAGE_CODES) | {"auto"}
 
 CONFIG_FILENAME = "koffee.toml"
 CONFIG_SEARCH_PATHS = [
@@ -37,6 +43,38 @@ class KoffeeConfig(BaseModel):
     overwrite: bool = False
     subtitle_track_index: int = 0
     use_embedded_subtitles: bool = False
+
+    @model_validator(mode="before")
+    @classmethod
+    def _resolve_api_key(cls, values: dict) -> dict:
+        """Falls back to the GOOGLE_API_KEY environment variable."""
+        if values.get("api_key") is None:
+            values["api_key"] = os.environ.get("GOOGLE_API_KEY")
+        return values
+
+    @field_validator("source_language", "target_language")
+    @classmethod
+    def _validate_language(cls, value: str) -> str:
+        """Validates that the language code is supported by Whisper."""
+        if value not in LANGUAGE_CODES:
+            error_message = (
+                f"Unsupported language code: {value!r}. "
+                f"Use one of: {', '.join(sorted(LANGUAGE_CODES - {'auto'}))}"
+            )
+            raise ValueError(error_message)
+        return value
+
+    @field_validator("model")
+    @classmethod
+    def _validate_model(cls, value: str) -> str:
+        """Validates that the model name is a known Whisper model."""
+        if value not in WHISPER_MODELS:
+            error_message = (
+                f"Unknown Whisper model: {value!r}. "
+                f"Available models: {', '.join(sorted(WHISPER_MODELS))}"
+            )
+            raise ValueError(error_message)
+        return value
 
 
 def load_config_file(path: Path | None = None) -> dict:

--- a/src/koffee/exceptions.py
+++ b/src/koffee/exceptions.py
@@ -6,7 +6,7 @@ class InvalidSubtitleFormatError(Exception):
 
 
 class InvalidVideoFileError(Exception):
-    """Input file is not a valid video file error."""
+    """Invalid video file error."""
 
 
 class SubtitleOverlayError(Exception):

--- a/src/koffee/translate.py
+++ b/src/koffee/translate.py
@@ -54,7 +54,7 @@ def translate(
 def _validate_file(video_file_path: Path | str) -> None:
     """Raises InvalidVideoFileError if the file does not exist or is not a file."""
     if not Path(video_file_path).exists() or not Path(video_file_path).is_file():
-        error_message = "Inputted file is not valid or does not exist."
+        error_message = "Input file is not valid or does not exist."
         log.error(error_message)
         raise InvalidVideoFileError(error_message)
 

--- a/src/koffee/utils/ass_converter.py
+++ b/src/koffee/utils/ass_converter.py
@@ -4,6 +4,8 @@ import logging
 import uuid
 from pathlib import Path
 
+from koffee.utils.timestamp_converter import convert_to_timestamp
+
 log = logging.getLogger(__name__)
 
 _STYLE_FORMAT = (
@@ -49,20 +51,10 @@ def convert_text_to_ass(transcript: list, output_dir: Path) -> Path:
         file.write(ASS_HEADER)
 
         for subtitle in transcript:
-            start = _seconds_to_ass_timestamp(subtitle["start"])
-            end = _seconds_to_ass_timestamp(subtitle["end"])
+            start = convert_to_timestamp(subtitle["start"], "ass")
+            end = convert_to_timestamp(subtitle["end"], "ass")
             text = subtitle["text"].strip().replace("\n", "\\N")
             file.write(f"Dialogue: 0,{start},{end},Default,,0,0,0,,{text}\n")
 
     log.debug(repr(output_file_path))
     return output_file_path
-
-
-def _seconds_to_ass_timestamp(seconds: float) -> str:
-    """Converts seconds to ASS timestamp format (H:MM:SS.cc)."""
-    total_cs = int(seconds * 100)
-    h = total_cs // 360000
-    m = (total_cs % 360000) // 6000
-    s = (total_cs % 6000) // 100
-    cs = total_cs % 100
-    return f"{h}:{m:02}:{s:02}.{cs:02}"

--- a/src/koffee/utils/timestamp_converter.py
+++ b/src/koffee/utils/timestamp_converter.py
@@ -25,6 +25,9 @@ def convert_to_timestamp(seconds: float | int, subtitle_format: str) -> str:
         timestamp = f"{hours:02}:{minutes:02}:{seconds:02},{ms:03}"
     elif subtitle_format == "vtt":
         timestamp = f"{hours:02}:{minutes:02}:{seconds:02}.{ms:03}"
+    elif subtitle_format == "ass":
+        cs = ms // 10
+        timestamp = f"{hours}:{minutes:02}:{seconds:02}.{cs:02}"
     else:
         error_message = f"Invalid or unsupported subtitle format: {subtitle_format}"
         raise InvalidSubtitleFormatError(error_message)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -48,7 +48,7 @@ def test_api() -> None:
 
 def test_invalid_video_file() -> None:
     """Tests that the appropriate error is raised when an invalid file is given."""
-    error_message = "Inputted file is not valid or does not exist."
+    error_message = "Input file is not valid or does not exist."
     with pytest.raises(InvalidVideoFileError, match=error_message):
         koffee.translate("invalid_file.mp4")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,7 @@
 """Tests for config file loading."""
 
+import pytest
+
 from koffee.data.config import KoffeeConfig, load_config_file
 
 
@@ -49,3 +51,54 @@ def test_config_file_values_apply_to_koffee_config(tmp_path) -> None:
     # Defaults should still apply for unset fields
     assert config.target_language == "en"
     assert config.device == "auto"
+
+
+def test_invalid_language_code_raises() -> None:
+    """Tests that an invalid language code raises a validation error."""
+    with pytest.raises(ValueError, match="Unsupported language code"):
+        KoffeeConfig(target_language="enn")
+
+
+def test_invalid_source_language_code_raises() -> None:
+    """Tests that an invalid source language code raises a validation error."""
+    with pytest.raises(ValueError, match="Unsupported language code"):
+        KoffeeConfig(source_language="xyz")
+
+
+def test_auto_source_language_is_accepted() -> None:
+    """Tests that 'auto' is a valid source language."""
+    config = KoffeeConfig(source_language="auto")
+    assert config.source_language == "auto"
+
+
+def test_invalid_model_raises() -> None:
+    """Tests that an unknown Whisper model raises a validation error."""
+    with pytest.raises(ValueError, match="Unknown Whisper model"):
+        KoffeeConfig(model="nonexistent-model")
+
+
+def test_valid_model_is_accepted() -> None:
+    """Tests that a known Whisper model is accepted."""
+    config = KoffeeConfig(model="tiny")
+    assert config.model == "tiny"
+
+
+def test_api_key_falls_back_to_env_var(monkeypatch) -> None:
+    """Tests that api_key falls back to the GOOGLE_API_KEY environment variable."""
+    monkeypatch.setenv("GOOGLE_API_KEY", "env-key-123")
+    config = KoffeeConfig()
+    assert config.api_key == "env-key-123"
+
+
+def test_api_key_prefers_explicit_value(monkeypatch) -> None:
+    """Tests that an explicit api_key takes precedence over the env var."""
+    monkeypatch.setenv("GOOGLE_API_KEY", "env-key-123")
+    config = KoffeeConfig(api_key="explicit-key")
+    assert config.api_key == "explicit-key"
+
+
+def test_api_key_is_none_without_env_var(monkeypatch) -> None:
+    """Tests that api_key is None when neither flag nor env var is set."""
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    config = KoffeeConfig()
+    assert config.api_key is None

--- a/tests/test_timestamp.py
+++ b/tests/test_timestamp.py
@@ -11,6 +11,7 @@ from koffee.utils import convert_to_timestamp
     [
         ("srt"),
         ("vtt"),
+        ("ass"),
     ],
 )
 def test_convert_to_timestamp(subtitle_format: str) -> None:
@@ -25,6 +26,11 @@ def test_convert_to_timestamp(subtitle_format: str) -> None:
             10.5: "00:00:10.500",
             60.12: "00:01:00.120",
             3600: "01:00:00.000",
+        },
+        "ass": {
+            10.5: "0:00:10.50",
+            60.12: "0:01:00.12",
+            3600: "1:00:00.00",
         },
     }
 


### PR DESCRIPTION
## Summary
- Add validation for language codes and Whisper model names in KoffeeConfig
- Fall back to `GOOGLE_API_KEY` env var when `--api_key` is not provided
- Fix "Inputted file" grammar in error messages
- Consolidate ASS timestamp conversion into shared `convert_to_timestamp()`
- Document config file format, precedence, compute types, and env var in README

## Test plan
- [x] `make build` passes (125 tests, 97% coverage)
- [x] New tests for invalid language codes, invalid models, env var fallback
- [x] ASS timestamp format added to parametrized timestamp tests
- [x] Existing tests updated for new error message wording