### PR TITLE
Add --no-vad-filter flag to disable VAD filtering

### DIFF
--- a/koffee/asr.py
+++ b/koffee/asr.py
@@ -19,12 +19,15 @@ def transcribe_text(
     model: str,
     translator: str,
     on_progress: Callable[[float], None] | None = None,
+    vad_filter: bool = True,
 ) -> dict:
     """Transcribes text from a video file."""
     log.info("Transcribing text.")
 
     loaded_model = _load_model(compute_type, device, model)
-    segments, info = _run_transcription(loaded_model, video_file, translator)
+    segments, info = _run_transcription(
+        loaded_model, video_file, translator, vad_filter
+    )
 
     transcript = {
         "segments": _consume_segments(segments, video_file, on_progress),
@@ -47,12 +50,12 @@ def _load_model(compute_type: str, device: str, model: str) -> WhisperModel:
 
 
 def _run_transcription(
-    loaded_model: WhisperModel, video_file: str, translator: str
+    loaded_model: WhisperModel, video_file: str, translator: str, vad_filter: bool
 ) -> tuple:
     """Runs transcription on the video file, returning segments and info."""
     task = "translate" if translator == "whisper" else "transcribe"
     segments, info = loaded_model.transcribe(
-        video_file, task=task, word_timestamps=True, vad_filter=True
+        video_file, task=task, word_timestamps=True, vad_filter=vad_filter
     )
 
     return segments, info

--- a/koffee/cli.py
+++ b/koffee/cli.py
@@ -106,6 +106,9 @@ def cli(
     api_key: Annotated[str, Parameter(name=("--api-key",))] | None = None,
     config: Annotated[Path, Parameter(name=("--config",), group=options_group)]
     | None = None,
+    no_vad_filter: Annotated[
+        bool, Parameter(name=("--no-vad-filter",), group=options_group)
+    ] = False,
     dry_run: Annotated[
         bool, Parameter(name=("--dry-run",), group=options_group)
     ] = False,
@@ -151,6 +154,8 @@ def cli(
         Path to a koffee.toml configuration file
     api_key: str
         API key for an LLM service
+    no_vad_filter: bool
+        Disable voice activity detection filtering during transcription
     dry_run: bool
         Preview what would be done without running transcription or translation
     overwrite: bool
@@ -179,6 +184,7 @@ def cli(
         "target_language": target_language,
         "translator": translator,
         "prompt": prompt,
+        "vad_filter": not no_vad_filter,
     }
     defaults = KoffeeConfig().model_dump()
     cli_overrides = {k: v for k, v in cli_args.items() if v != defaults.get(k)}
@@ -503,6 +509,9 @@ def transcribe(
     subtitle_format: Annotated[
         str, Parameter(name=("--subtitle-format", "-f"))
     ] = options.subtitle_format,
+    no_vad_filter: Annotated[
+        bool, Parameter(name=("--no-vad-filter",), group=options_group)
+    ] = False,
     overwrite: Annotated[
         bool, Parameter(name=("--overwrite",), group=options_group)
     ] = False,
@@ -525,6 +534,8 @@ def transcribe(
         Name of the output file
     subtitle_format: str
         Format to use for the subtitles
+    no_vad_filter: bool
+        Disable voice activity detection filtering during transcription
     overwrite: bool
         Overwrite existing output files instead of raising an error
     """
@@ -538,6 +549,7 @@ def transcribe(
             whisper_model,
             "whisper",
             on_progress=_make_progress_callback(progress, asr_task),
+            vad_filter=not no_vad_filter,
         )
 
     segments = transcript["segments"]

--- a/koffee/data/config.py
+++ b/koffee/data/config.py
@@ -146,6 +146,7 @@ class KoffeeConfig(BaseModel):
     prompt: str | None = None
     dry_run: bool = False
     overwrite: bool = False
+    vad_filter: bool = True
     subtitle_track_index: int = 0
     use_embedded_subtitles: bool = False
 

--- a/koffee/translate.py
+++ b/koffee/translate.py
@@ -93,6 +93,7 @@ def _transcribe(
         config.whisper_model,
         config.translator,
         on_progress=on_progress,
+        vad_filter=config.vad_filter,
     )
 
     return transcript


### PR DESCRIPTION
## Summary

- Adds `--no-vad-filter` flag to the default and `transcribe` commands
- VAD filtering defaults to `true`; pass `--no-vad-filter` to disable it
- Threads `vad_filter` through `KoffeeConfig`, `transcribe_text`, and `_run_transcription`

## Test plan

- [ ] `koffee video.mp4` — VAD filter on by default (no change in behavior)
- [ ] `koffee video.mp4 --no-vad-filter` — VAD filter disabled
- [ ] `koffee transcribe video.mp4 --no-vad-filter` — same for transcribe command