### PR TITLE
Rename `translator` config/flag/param to `provider`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Refer below for a list of all arguments, commands, parameters, and options.
     --target-language       -t  Language to which the file should be translated
     --subtitle-format       -f  Format to use for the subtitles
     --embed                     Subtitle embed mode: none, soft, or hard
-    --translator                The backend service to use for the translation (whisper, gemini, chatgpt, claude, ollama)
+    --provider                  The backend service to use for the translation (whisper, gemini, chatgpt, claude, ollama)
     --llm-model                 The LLM model to use for translation
     --chunk-size                Number of subtitle entries per LLM request (auto-selected per model if unset)
     --context-size              Number of preceding entries passed as context per request (auto-selected per model if unset)
@@ -123,7 +123,7 @@ whisper-model = "large-v3"
 source-language = "ko"
 target-language = "en"
 subtitle-format = "srt"
-translator = "gemini"
+provider = "gemini"
 llm-model = "gemini-2.5-flash"
 chunk-size = 400
 context-size = 20

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,13 +25,13 @@ Set your API key as an environment variable to use but it also passable as an ar
 
 ```console
 export GEMINI_API_KEY=<your-api-key>
-koffee audio_file.mp3 --translator=gemini
+koffee audio_file.mp3 --provider=gemini
 ```
 
 or
 
 ```
-koffee audio_file.mp3 --translator=gemini --api-key=<your-api-key>
+koffee audio_file.mp3 --provider=gemini --api-key=<your-api-key>
 ```
 
 There is full feature parity between the CLI and the Python library. See the example below for basic usage:

--- a/koffee/api.py
+++ b/koffee/api.py
@@ -61,9 +61,9 @@ def _validate_file(video_file_path: Path | str) -> None:
 
 def _validate_api_key(config: KoffeeConfig) -> None:
     """Raises ValueError if an LLM backend is selected without an API key."""
-    if config.translator not in ("whisper", "ollama") and not config.api_key:
+    if config.provider not in ("whisper", "ollama") and not config.api_key:
         error_message = (
-            f"An API key is required when using the {config.translator} "
+            f"An API key is required when using the {config.provider} "
             "translation backend. Provide one with --api_key or set the appropriate "
             "environment variable."
         )
@@ -91,7 +91,7 @@ def _transcribe(
         config.compute_type,
         config.device,
         config.whisper_model,
-        config.translator,
+        config.provider,
         on_progress=on_progress,
         vad_filter=config.vad_filter,
     )
@@ -187,7 +187,7 @@ def _translate_subtitle_file(
         on_progress,
         llm_model=config.llm_model,
         prompt=config.prompt,
-        translator=config.translator,
+        provider=config.provider,
     )
     translated_path = generate_subtitles(config.subtitle_format, translated_segments)
     output_path = _get_output_path(file_path, config.output_dir, config.output_name)
@@ -230,7 +230,7 @@ def _get_segments(
     on_progress: Callable[[float], None] | None = None,
 ) -> list:
     """Returns translated or raw segments based on the translation backend."""
-    if config.translator == "whisper":
+    if config.provider == "whisper":
         segments = transcript["segments"]
     else:
         segments = translate(
@@ -240,7 +240,7 @@ def _get_segments(
             on_progress,
             llm_model=config.llm_model,
             prompt=config.prompt,
-            translator=config.translator,
+            provider=config.provider,
             chunk_size=config.chunk_size,
             context_size=config.context_size,
         )

--- a/koffee/asr.py
+++ b/koffee/asr.py
@@ -17,7 +17,7 @@ def transcribe(
     compute_type: str,
     device: str,
     model: str,
-    translator: str,
+    provider: str,
     on_progress: Callable[[float], None] | None = None,
     vad_filter: bool = True,
 ) -> dict:
@@ -25,9 +25,7 @@ def transcribe(
     log.info("Transcribing file.")
 
     loaded_model = _load_model(compute_type, device, model)
-    segments, info = _run_transcription(
-        loaded_model, video_file, translator, vad_filter
-    )
+    segments, info = _run_transcription(loaded_model, video_file, provider, vad_filter)
 
     transcript = {
         "segments": _consume_segments(segments, video_file, on_progress),
@@ -50,10 +48,10 @@ def _load_model(compute_type: str, device: str, model: str) -> WhisperModel:
 
 
 def _run_transcription(
-    loaded_model: WhisperModel, video_file: str, translator: str, vad_filter: bool
+    loaded_model: WhisperModel, video_file: str, provider: str, vad_filter: bool
 ) -> tuple:
     """Runs transcription on the video file, returning segments and info."""
-    task = "translate" if translator == "whisper" else "transcribe"
+    task = "translate" if provider == "whisper" else "transcribe"
     segments, info = loaded_model.transcribe(
         video_file, task=task, word_timestamps=True, vad_filter=vad_filter
     )

--- a/koffee/cli.py
+++ b/koffee/cli.py
@@ -97,7 +97,7 @@ def cli(
         str, Parameter(name=("--subtitle-format", "-f"))
     ] = defaults.subtitle_format,
     embed: Annotated[str, Parameter(name=("--embed",))] = defaults.embed,
-    translator: Annotated[str, Parameter(name=("--translator",))] = defaults.translator,
+    provider: Annotated[str, Parameter(name=("--provider",))] = defaults.provider,
     llm_model: Annotated[str, Parameter(name=("--llm-model",))] | None = None,
     chunk_size: Annotated[int, Parameter(name=("--chunk-size",))] | None = None,
     context_size: Annotated[int, Parameter(name=("--context-size",))] | None = None,
@@ -143,7 +143,7 @@ def cli(
         Source language of the subtitle file (default: auto)
     target_language: str
         Language to which the file should be translated
-    translator: str
+    provider: str
         The backend service to use for the translation
     llm_model: str
         The LLM model to use for translation
@@ -181,7 +181,7 @@ def cli(
         "source_language": source_language,
         "subtitle_format": subtitle_format,
         "target_language": target_language,
-        "translator": translator,
+        "provider": provider,
         "prompt": prompt,
         "vad_filter": not no_vad_filter,
     }
@@ -238,7 +238,7 @@ def _print_dry_run(resolved_paths: list[Path], config: KoffeeConfig) -> None:
         elif config.use_embedded_subtitles:
             mode = "embedded subtitle extraction + translation"
         else:
-            mode = f"ASR ({config.whisper_model}) + translation ({config.translator})"
+            mode = f"ASR ({config.whisper_model}) + translation ({config.provider})"
         log.info(f"  {path.name} -> {mode}")
 
     log.info(f"[dry-run] Target language: {config.target_language}")
@@ -352,7 +352,7 @@ def _translate_with_progress(
             on_translate_progress=_make_progress_callback(progress, translate_task),
         )
     else:
-        has_translate_step = config.translator != "whisper"
+        has_translate_step = config.provider != "whisper"
         asr_task = progress.add_task("Transcribing", total=100)
         translate_task = None
         translate_callback = None
@@ -414,7 +414,7 @@ def info() -> None:
 
     config = KoffeeConfig(**load_config_file())
     log.info(f"  default whisper model: {config.whisper_model}")
-    log.info(f"  default backend: {config.translator}")
+    log.info(f"  default backend: {config.provider}")
     log.info(f"  config file: {_find_config_path() or 'none'}")
 
 

--- a/koffee/data/config.py
+++ b/koffee/data/config.py
@@ -139,7 +139,7 @@ class KoffeeConfig(BaseModel):
     source_language: str = "auto"
     subtitle_format: Literal["srt", "vtt", "ass"] = "vtt"
     target_language: str = "en"
-    translator: Literal["whisper", "gemini", "chatgpt", "claude", "ollama"] = "whisper"
+    provider: Literal["whisper", "gemini", "chatgpt", "claude", "ollama"] = "whisper"
     llm_model: str | None = None
     chunk_size: int | None = None
     context_size: int | None = None
@@ -162,7 +162,7 @@ class KoffeeConfig(BaseModel):
             "chatgpt": "OPENAI_API_KEY",
             "claude": "ANTHROPIC_API_KEY",
         }
-        backend = values.get("translator", "whisper")
+        backend = values.get("provider", "whisper")
         env_var = env_vars.get(backend)
         if env_var:
             values["api_key"] = os.environ.get(env_var)

--- a/koffee/translator.py
+++ b/koffee/translator.py
@@ -70,27 +70,27 @@ def translate(
     on_progress: Callable[[float], None] | None = None,
     llm_model: str | None = None,
     prompt: str | None = None,
-    translator: str = "gemini",
+    provider: str = "gemini",
     chunk_size: int | None = None,
     context_size: int | None = None,
 ) -> list:
     """Translates a transcript using an LLM backend, preserving timing information."""
-    log.info(f"Translating transcript with {translator}.")
+    log.info(f"Translating transcript with {provider}.")
 
     system_prompt = prompt if prompt else SYSTEM_PROMPT
-    model = llm_model or DEFAULT_MODEL.get(translator, "")
+    model = llm_model or DEFAULT_MODEL.get(provider, "")
     resolved_chunk_size = chunk_size or CHUNK_SIZE_BY_MODEL.get(model, CHUNK_SIZE)
     resolved_context_size = (
         context_size
         if context_size is not None
         else CONTEXT_SIZE_BY_MODEL.get(model, CONTEXT_SIZE)
     )
-    backend = _load_backend(translator)
+    backend = _load_backend(provider)
     client = backend.create_client(api_key)
     chunks = _chunk_segments(transcript, target_language, resolved_chunk_size)
     translated_segments = _translate_chunks(
         backend,
-        backend_name=translator,
+        backend_name=provider,
         client=client,
         chunks=chunks,
         on_progress=on_progress,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -87,7 +87,7 @@ def test_get_segments_whisper_returns_raw(mocker, api_module) -> None:
     """Tests that whisper backend returns raw segments without translation."""
     mock_translate = mocker.patch.object(api_module, "translate")
     config = MagicMock(spec=KoffeeConfig)
-    config.translator = "whisper"
+    config.provider = "whisper"
     transcript = {"segments": [{"start": 0.0, "end": 1.0, "text": "hi"}]}
 
     result = _get_segments(transcript, config)
@@ -102,7 +102,7 @@ def test_get_segments_non_whisper_calls_translate(mocker, api_module) -> None:
         api_module, "translate", return_value=["translated"]
     )
     config = MagicMock(spec=KoffeeConfig)
-    config.translator = "gemini"
+    config.provider = "gemini"
     config.target_language = "en"
     config.api_key = None
     config.llm_model = "gemini-2.5-flash"
@@ -121,7 +121,7 @@ def test_get_segments_non_whisper_calls_translate(mocker, api_module) -> None:
         None,
         llm_model=config.llm_model,
         prompt=config.prompt,
-        translator=config.translator,
+        provider=config.provider,
         chunk_size=config.chunk_size,
         context_size=config.context_size,
     )
@@ -158,7 +158,7 @@ def test_validate_api_key_raises_without_key() -> None:
     with pytest.raises(ValueError, match="API key is required"):
         koffee.run(
             "examples/videos/sample_korean_video.mp4",
-            translator="gemini",
+            provider="gemini",
         )
 
 
@@ -166,7 +166,7 @@ def test_validate_api_key_ollama_does_not_require_key() -> None:
     """Tests that ollama backend does not require an API key."""
     from koffee.api import _validate_api_key  # noqa: PLC0415
 
-    config = KoffeeConfig(translator="ollama", whisper_model="large-v3")
+    config = KoffeeConfig(provider="ollama", whisper_model="large-v3")
     _validate_api_key(config)
 
 
@@ -241,7 +241,7 @@ def test_run_subtitle_file_input(mocker, api_module, tmp_path) -> None:
         str(srt),
         config=KoffeeConfig(
             output_dir=tmp_path,
-            translator="gemini",
+            provider="gemini",
             api_key="test-key",
             overwrite=True,
         ),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -37,7 +37,7 @@ def test_config_file_values_apply_to_koffee_config(tmp_path) -> None:
     """Tests that config file values override KoffeeConfig defaults."""
     config_path = tmp_path / "koffee.toml"
     config_path.write_text(
-        'source_language = "ko"\nsubtitle_format = "srt"\ntranslator = "gemini"\n'
+        'source_language = "ko"\nsubtitle_format = "srt"\nprovider = "gemini"\n'
     )
 
     file_config = load_config_file(config_path)
@@ -45,7 +45,7 @@ def test_config_file_values_apply_to_koffee_config(tmp_path) -> None:
 
     assert config.source_language == "ko"
     assert config.subtitle_format == "srt"
-    assert config.translator == "gemini"
+    assert config.provider == "gemini"
     # Defaults should still apply for unset fields
     assert config.target_language == "en"
     assert config.device == "auto"
@@ -84,34 +84,34 @@ def test_valid_whisper_model_is_accepted() -> None:
 def test_api_key_falls_back_to_google_env_var(monkeypatch) -> None:
     """Tests that api_key falls back to GOOGLE_API_KEY for gemini backend."""
     monkeypatch.setenv("GOOGLE_API_KEY", "env-key-123")
-    config = KoffeeConfig(translator="gemini")
+    config = KoffeeConfig(provider="gemini")
     assert config.api_key == "env-key-123"
 
 
 def test_api_key_falls_back_to_openai_env_var(monkeypatch) -> None:
     """Tests that api_key falls back to OPENAI_API_KEY for chatgpt backend."""
     monkeypatch.setenv("OPENAI_API_KEY", "openai-key-123")
-    config = KoffeeConfig(translator="chatgpt")
+    config = KoffeeConfig(provider="chatgpt")
     assert config.api_key == "openai-key-123"
 
 
 def test_api_key_falls_back_to_anthropic_env_var(monkeypatch) -> None:
     """Tests that api_key falls back to ANTHROPIC_API_KEY for claude backend."""
     monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-key-123")
-    config = KoffeeConfig(translator="claude")
+    config = KoffeeConfig(provider="claude")
     assert config.api_key == "anthropic-key-123"
 
 
 def test_api_key_not_resolved_for_whisper() -> None:
     """Tests that no env var is checked for the whisper backend."""
-    config = KoffeeConfig(translator="whisper")
+    config = KoffeeConfig(provider="whisper")
     assert config.api_key is None
 
 
 def test_api_key_prefers_explicit_value(monkeypatch) -> None:
     """Tests that an explicit api_key takes precedence over the env var."""
     monkeypatch.setenv("GOOGLE_API_KEY", "env-key-123")
-    config = KoffeeConfig(api_key="explicit-key", translator="gemini")
+    config = KoffeeConfig(api_key="explicit-key", provider="gemini")
     assert config.api_key == "explicit-key"
 
 

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -126,7 +126,7 @@ def test_translate_single_chunk(mocker: MockerFixture) -> None:
         "2\n00:00:07,800 --> 00:00:10,740\nHow have you been?"
     )
 
-    result = translate(SAMPLE_TRANSCRIPT, "en", api_key=None, translator="gemini")
+    result = translate(SAMPLE_TRANSCRIPT, "en", api_key=None, provider="gemini")
 
     assert len(result) == 2
     assert result[0]["text"] == "Hello."
@@ -145,7 +145,7 @@ def test_translate_sleeps_between_chunks(mocker: MockerFixture) -> None:
         "1\n00:00:00,000 --> 00:00:06,360\nHello."
     )
 
-    translate(SAMPLE_TRANSCRIPT, "en", api_key=None, translator="gemini")
+    translate(SAMPLE_TRANSCRIPT, "en", api_key=None, provider="gemini")
 
     # 2 segments with chunk size 1 = 2 chunks, sleep called once (not after last chunk)
     assert mock_sleep.call_count == 1
@@ -160,7 +160,7 @@ def test_translate_passes_api_key(mocker: MockerFixture) -> None:
     )
     mocker.patch("koffee.translator.time.sleep")
 
-    translate(SAMPLE_TRANSCRIPT, "en", api_key="test-key", translator="gemini")
+    translate(SAMPLE_TRANSCRIPT, "en", api_key="test-key", provider="gemini")
 
     mock_create.assert_called_once_with("test-key")
 
@@ -254,7 +254,7 @@ def test_translate_reports_progress(mocker: MockerFixture) -> None:
         "en",
         api_key=None,
         on_progress=progress_calls.append,
-        translator="gemini",
+        provider="gemini",
     )
 
     assert progress_calls == [0.5, 1.0]
@@ -335,7 +335,7 @@ def test_translate_uses_custom_prompt(mocker: MockerFixture) -> None:
         "en",
         api_key=None,
         prompt=custom_prompt,
-        translator="gemini",
+        provider="gemini",
     )
 
     call_kwargs = mock_client.models.generate_content.call_args.kwargs
@@ -355,7 +355,7 @@ def test_translate_falls_back_to_default_prompt(
         "2\n00:00:07,800 --> 00:00:10,740\nHow have you been?"
     )
 
-    translate(SAMPLE_TRANSCRIPT, "en", api_key=None, translator="gemini")
+    translate(SAMPLE_TRANSCRIPT, "en", api_key=None, provider="gemini")
 
     call_kwargs = mock_client.models.generate_content.call_args.kwargs
     assert call_kwargs["config"]["system_instruction"] == SYSTEM_PROMPT
@@ -414,7 +414,7 @@ def test_translate_uses_default_model(mocker: MockerFixture) -> None:
         "2\n00:00:07,800 --> 00:00:10,740\nHow have you been?"
     )
 
-    translate(SAMPLE_TRANSCRIPT, "en", api_key=None, translator="gemini")
+    translate(SAMPLE_TRANSCRIPT, "en", api_key=None, provider="gemini")
 
     call_kwargs = mock_client.models.generate_content.call_args.kwargs
     assert call_kwargs["model"] == "gemini-2.5-flash"
@@ -509,9 +509,7 @@ def test_chatgpt_translate(mocker: MockerFixture) -> None:
     )
     mock_client.chat.completions.create.return_value = mock_response
 
-    result = translate(
-        SAMPLE_TRANSCRIPT, "en", api_key="test-key", translator="chatgpt"
-    )
+    result = translate(SAMPLE_TRANSCRIPT, "en", api_key="test-key", provider="chatgpt")
 
     assert len(result) == 2
     assert result[0]["text"] == "Hello."
@@ -628,7 +626,7 @@ def test_claude_translate(mocker: MockerFixture) -> None:
     )
     mock_client.messages.create.return_value = mock_response
 
-    result = translate(SAMPLE_TRANSCRIPT, "en", api_key="test-key", translator="claude")
+    result = translate(SAMPLE_TRANSCRIPT, "en", api_key="test-key", provider="claude")
 
     assert len(result) == 2
     assert result[0]["text"] == "Hello."
@@ -733,7 +731,7 @@ def test_ollama_translate(mocker: MockerFixture) -> None:
     )
     mock_client.chat.completions.create.return_value = mock_response
 
-    result = translate(SAMPLE_TRANSCRIPT, "en", api_key=None, translator="ollama")
+    result = translate(SAMPLE_TRANSCRIPT, "en", api_key=None, provider="ollama")
 
     assert len(result) == 2
     assert result[0]["text"] == "Hello."
@@ -754,7 +752,7 @@ def test_ollama_translate_uses_default_model(mocker: MockerFixture) -> None:
     )
     mock_client.chat.completions.create.return_value = mock_response
 
-    translate(SAMPLE_TRANSCRIPT, "en", api_key=None, translator="ollama")
+    translate(SAMPLE_TRANSCRIPT, "en", api_key=None, provider="ollama")
 
     call_kwargs = mock_client.chat.completions.create.call_args.kwargs
     assert call_kwargs["model"] == "qwen3:14b"
@@ -817,7 +815,7 @@ def test_translate_uses_model_chunk_size(mocker: MockerFixture) -> None:
         {"segments": many_segments, "language": "ja"},
         "ko",
         api_key=None,
-        translator="ollama",
+        provider="ollama",
         llm_model=model,
     )
 
@@ -844,7 +842,7 @@ def test_translate_explicit_chunk_size_overrides_model_default(
         {"segments": segments, "language": "ja"},
         "ko",
         api_key=None,
-        translator="ollama",
+        provider="ollama",
         llm_model="qwen3:14b",
         chunk_size=2,
     )
@@ -879,7 +877,7 @@ def test_translate_uses_model_context_size(mocker: MockerFixture) -> None:
         {"segments": segments, "language": "ja"},
         "ko",
         api_key=None,
-        translator="ollama",
+        provider="ollama",
         llm_model=model,
         chunk_size=3,
     )
@@ -911,7 +909,7 @@ def test_translate_explicit_context_size_overrides_model_default(
         SAMPLE_TRANSCRIPT,
         "en",
         api_key=None,
-        translator="gemini",
+        provider="gemini",
         context_size=2,
     )
 
@@ -935,7 +933,7 @@ def test_translate_uses_default_context_size_for_unknown_model(
 
     mock_build = mocker.patch("koffee.translator._build_prompt", return_value="prompt")
 
-    translate(SAMPLE_TRANSCRIPT, "en", api_key=None, translator="gemini")
+    translate(SAMPLE_TRANSCRIPT, "en", api_key=None, provider="gemini")
 
     _, kwargs = mock_build.call_args
     assert len(kwargs["context_segments"]) <= CONTEXT_SIZE


### PR DESCRIPTION
Renames `translator` to `provider` across the config field, CLI flag, and Python kwargs on `translate()` / `asr.transcribe()`. The old name was overloaded with the `translator.py` module and `translate()` function; `provider` matches LLM-ecosystem convention (LangChain, LiteLLM, OpenRouter).