### PR TITLE
Add pre-flight input validation

### DIFF
--- a/koffee/api.py
+++ b/koffee/api.py
@@ -1,6 +1,7 @@
 """The koffee API."""
 
 import logging
+import shutil
 from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
@@ -9,10 +10,19 @@ from typing import Any
 from koffee.asr import transcribe
 from koffee.data.config import KoffeeConfig
 from koffee.embed import embed_subtitles
-from koffee.exceptions import InvalidVideoFileError
+from koffee.exceptions import (
+    IncompatibleOptionsError,
+    InvalidVideoFileError,
+    MissingDependencyError,
+    UnsupportedFileError,
+)
 from koffee.subtitle import generate_subtitles
 from koffee.translator import translate
-from koffee.utils import extract_subtitle_track, parse_subtitle_file
+from koffee.utils import (
+    extract_subtitle_track,
+    get_subtitle_tracks,
+    parse_subtitle_file,
+)
 
 log = logging.getLogger(__name__)
 
@@ -32,9 +42,8 @@ def run(
     """Processes a video or audio file for translation and subtitle generation."""
     log.info("Translating file...")
 
-    _validate_file(video_file_path)
     config = _apply_config_overrides(config, kwargs)
-    _validate_api_key(config)
+    _validate_inputs(video_file_path, config)
 
     if Path(video_file_path).suffix.lower() in SUBTITLE_EXTENSIONS:
         return _translate_subtitle_file(video_file_path, config, on_translate_progress)
@@ -57,6 +66,53 @@ def _validate_file(video_file_path: Path | str) -> None:
         error_message = "Input file is not valid or does not exist."
         log.error(error_message)
         raise InvalidVideoFileError(error_message)
+
+
+def _validate_inputs(video_file_path: Path | str, config: KoffeeConfig) -> None:
+    """Runs pre-flight checks on the input file, dependencies, and config options."""
+    _validate_file(video_file_path)
+
+    suffix = Path(video_file_path).suffix.lower()
+    allowed = SUPPORTED_EXTENSIONS | SUBTITLE_EXTENSIONS
+    if suffix not in allowed:
+        error_message = (
+            f"Unsupported file type: {suffix!r}. "
+            f"Supported extensions: {', '.join(sorted(allowed))}"
+        )
+        raise UnsupportedFileError(error_message)
+
+    is_video = suffix in VIDEO_EXTENSIONS
+
+    if config.embed != "none" and not is_video:
+        error_message = "--embed is only supported for video file inputs."
+        raise IncompatibleOptionsError(error_message)
+
+    if config.use_embedded_subtitles and not is_video:
+        error_message = (
+            "--use-embedded-subtitles is only supported for video file inputs."
+        )
+        raise IncompatibleOptionsError(error_message)
+
+    needs_ffmpeg = config.embed != "none" or config.use_embedded_subtitles
+    if needs_ffmpeg and shutil.which("ffmpeg") is None:
+        error_message = (
+            "ffmpeg was not found on PATH. Install ffmpeg to use --embed or "
+            "--use-embedded-subtitles."
+        )
+        raise MissingDependencyError(error_message)
+
+    if config.use_embedded_subtitles:
+        if shutil.which("ffprobe") is None:
+            error_message = (
+                "ffprobe was not found on PATH. Install ffmpeg to use "
+                "--use-embedded-subtitles."
+            )
+            raise MissingDependencyError(error_message)
+        if not get_subtitle_tracks(video_file_path):
+            error_message = f"No embedded subtitle tracks found in {video_file_path}."
+            raise IncompatibleOptionsError(error_message)
+
+    _validate_api_key(config)
 
 
 def _validate_api_key(config: KoffeeConfig) -> None:

--- a/koffee/exceptions.py
+++ b/koffee/exceptions.py
@@ -1,13 +1,25 @@
 """Exceptions for koffee."""
 
 
+class IncompatibleOptionsError(Exception):
+    """Config options incompatible with the input file."""
+
+
 class InvalidSubtitleFormatError(Exception):
-    """Invalid subtitle format error."""
+    """Subtitle format is invalid or not supported."""
 
 
 class InvalidVideoFileError(Exception):
-    """Invalid video file error."""
+    """Video file is invalid or does not exist."""
+
+
+class MissingDependencyError(Exception):
+    """Required external executable not found on PATH."""
 
 
 class SubtitleEmbedError(Exception):
-    """Subtitle embed error."""
+    """Subtitle embedding not possible for the given file."""
+
+
+class UnsupportedFileError(Exception):
+    """Input file has an unsupported extension."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,10 +15,16 @@ from koffee.api import (
     _get_segments,
     _handle_subtitle_output,
     _route_output,
+    _validate_inputs,
     run,
 )
 from koffee.data.config import KoffeeConfig
-from koffee.exceptions import InvalidVideoFileError
+from koffee.exceptions import (
+    IncompatibleOptionsError,
+    InvalidVideoFileError,
+    MissingDependencyError,
+    UnsupportedFileError,
+)
 
 
 @pytest.fixture
@@ -250,6 +256,65 @@ def test_run_subtitle_file_input(mocker, api_module, tmp_path) -> None:
     mock_parse.assert_called_once()
     mock_translate.assert_called_once()
     mock_generate.assert_called_once()
+
+
+def test_validate_inputs_rejects_unsupported_suffix(tmp_path) -> None:
+    """Tests that an unsupported file extension raises UnsupportedFileError."""
+    bad_file = tmp_path / "notes.txt"
+    bad_file.touch()
+
+    with pytest.raises(UnsupportedFileError, match="Unsupported file type"):
+        _validate_inputs(bad_file, KoffeeConfig())
+
+
+def test_validate_inputs_rejects_embed_on_audio(tmp_path) -> None:
+    """Tests that --embed on audio input raises IncompatibleOptionsError."""
+    audio = tmp_path / "track.mp3"
+    audio.touch()
+
+    with pytest.raises(IncompatibleOptionsError, match="--embed is only supported"):
+        _validate_inputs(audio, KoffeeConfig(embed="soft"))
+
+
+def test_validate_inputs_rejects_embedded_subs_on_audio(tmp_path) -> None:
+    """Tests that --use-embedded-subtitles on audio raises IncompatibleOptionsError."""
+    audio = tmp_path / "track.mp3"
+    audio.touch()
+
+    with pytest.raises(
+        IncompatibleOptionsError, match="--use-embedded-subtitles is only supported"
+    ):
+        _validate_inputs(audio, KoffeeConfig(use_embedded_subtitles=True))
+
+
+def test_validate_inputs_rejects_missing_ffmpeg(mocker, tmp_path) -> None:
+    """Tests that missing ffmpeg raises MissingDependencyError when embedding."""
+    video = tmp_path / "clip.mp4"
+    video.touch()
+    mocker.patch("koffee.api.shutil.which", return_value=None)
+
+    with pytest.raises(MissingDependencyError, match="ffmpeg was not found"):
+        _validate_inputs(video, KoffeeConfig(embed="soft"))
+
+
+def test_validate_inputs_rejects_no_embedded_tracks(mocker, tmp_path) -> None:
+    """Tests that a video with no subtitle tracks raises IncompatibleOptionsError."""
+    video = tmp_path / "clip.mp4"
+    video.touch()
+    mocker.patch("koffee.api.shutil.which", return_value="/usr/bin/ffmpeg")
+    mocker.patch("koffee.api.get_subtitle_tracks", return_value=[])
+
+    with pytest.raises(IncompatibleOptionsError, match="No embedded subtitle tracks"):
+        _validate_inputs(video, KoffeeConfig(use_embedded_subtitles=True))
+
+
+def test_validate_inputs_passes_on_valid_video(mocker, tmp_path) -> None:
+    """Tests that a valid video file with a valid config passes validation."""
+    video = tmp_path / "clip.mp4"
+    video.touch()
+    mocker.patch("koffee.api.shutil.which", return_value="/usr/bin/ffmpeg")
+
+    _validate_inputs(video, KoffeeConfig(embed="soft"))
 
 
 def test_handle_subtitle_output_audio_renames_subtitle(tmp_path) -> None:


### PR DESCRIPTION
Adds `_validate_inputs` to `koffee.api.run` so unsupported file types, audio+embed combinations, missing ffmpeg/ffprobe, and videos with no embedded subtitle tracks fail immediately with targeted exceptions (`UnsupportedFileError`, `IncompatibleOptionsError`, `MissingDependencyError`) instead of crashing mid-pipeline.