### PR TITLE
Dedup subtitle output writing

### DIFF
--- a/koffee/api.py
+++ b/koffee/api.py
@@ -199,10 +199,13 @@ def _route_output(
             config.target_language,
         )
     else:
-        target_path = output_path.with_suffix(f".{config.subtitle_format}")
-        _check_output_collision(target_path, config.overwrite)
-        output_file_path = _handle_subtitle_output(
-            subtitle_file_path, output_path, config.subtitle_format
+        output_file_path = _write_output(
+            subtitle_file_path,
+            video_file_path,
+            config.subtitle_format,
+            config.output_dir,
+            config.output_name,
+            config.overwrite,
         )
 
     return output_file_path
@@ -246,10 +249,14 @@ def _translate_subtitle_file(
         provider=config.provider,
     )
     translated_path = generate_subtitles(config.subtitle_format, translated_segments)
-    output_path = _get_output_path(file_path, config.output_dir, config.output_name)
-    output_subtitle_path = output_path.with_suffix(f".{config.subtitle_format}")
-    _check_output_collision(output_subtitle_path, config.overwrite)
-    translated_path.replace(output_subtitle_path)
+    output_subtitle_path = _write_output(
+        translated_path,
+        file_path,
+        config.subtitle_format,
+        config.output_dir,
+        config.output_name,
+        config.overwrite,
+    )
 
     return output_subtitle_path
 
@@ -325,12 +332,25 @@ def _finalize_video_output(
     return output_video
 
 
-def _handle_subtitle_output(
-    subtitle_file_path: Path, output_path: Path, subtitle_format: str
+def _write_output(
+    source_path: Path,
+    input_path: Path | str,
+    subtitle_format: str,
+    output_dir: Path | None,
+    output_name: str | None,
+    overwrite: bool,
 ) -> Path:
-    """Moves the subtitle file to the output path."""
-    output_subtitle_path = output_path.with_suffix(f".{subtitle_format}")
-    subtitle_file_path.replace(output_subtitle_path)
+    """Moves a generated subtitle file to its resolved output location."""
+    base_path = _get_output_path(input_path, output_dir, output_name)
+    target_path = base_path.with_suffix(f".{subtitle_format}")
+
+    try:
+        _check_output_collision(target_path, overwrite)
+    except FileExistsError:
+        source_path.unlink(missing_ok=True)
+        raise
+
+    source_path.replace(target_path)
     log.info("Finished processing file!")
 
-    return output_subtitle_path
+    return target_path

--- a/koffee/cli.py
+++ b/koffee/cli.py
@@ -21,7 +21,7 @@ from rich.progress import (
 from rich.table import Table
 
 from koffee import asr
-from koffee.api import SUBTITLE_EXTENSIONS, SUPPORTED_EXTENSIONS, run
+from koffee.api import SUBTITLE_EXTENSIONS, SUPPORTED_EXTENSIONS, _write_output, run
 from koffee.data.config import (
     CONFIG_SEARCH_PATHS,
     LANGUAGE_CODES,
@@ -583,19 +583,14 @@ def transcribe(
     out_dir = output_dir if output_dir is not None else file_path.parent
     subtitle_file_path = generate_subtitles(subtitle_format, segments, out_dir)
 
-    if output_name is not None:
-        target_path = out_dir / f"{output_name}.{subtitle_format}"
-    else:
-        target_path = out_dir / f"{file_path.stem}.{subtitle_format}"
-
-    if target_path.exists() and not overwrite:
-        subtitle_file_path.unlink(missing_ok=True)
-        error_message = (
-            f"Output file already exists: {target_path}. Use --overwrite to replace it."
-        )
-        raise FileExistsError(error_message)
-
-    subtitle_file_path.replace(target_path)
+    target_path = _write_output(
+        subtitle_file_path,
+        file_path,
+        subtitle_format,
+        output_dir,
+        output_name,
+        overwrite,
+    )
     log.info(f"Output saved to {target_path}")
 
 
@@ -628,19 +623,14 @@ def convert(
     out_dir = output_dir if output_dir is not None else file_path.parent
     subtitle_file_path = generate_subtitles(subtitle_format, segments, out_dir)
 
-    if output_name is not None:
-        target_path = out_dir / f"{output_name}.{subtitle_format}"
-    else:
-        target_path = out_dir / f"{file_path.stem}.{subtitle_format}"
-
-    if target_path.exists() and not overwrite:
-        subtitle_file_path.unlink(missing_ok=True)
-        error_message = (
-            f"Output file already exists: {target_path}. Use --overwrite to replace it."
-        )
-        raise FileExistsError(error_message)
-
-    subtitle_file_path.replace(target_path)
+    target_path = _write_output(
+        subtitle_file_path,
+        file_path,
+        subtitle_format,
+        output_dir,
+        output_name,
+        overwrite,
+    )
     log.info(f"Converted {file_path.name} to {target_path}")
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,9 +13,9 @@ from koffee.api import (
     _finalize_video_output,
     _get_output_path,
     _get_segments,
-    _handle_subtitle_output,
     _route_output,
     _validate_inputs,
+    _write_output,
     run,
 )
 from koffee.data.config import KoffeeConfig
@@ -146,17 +146,48 @@ def test_finalize_video_output_deletes_subtitle(mocker, tmp_path, api_module) ->
     assert not subtitle.exists()
 
 
-def test_handle_subtitle_output_renames_subtitle(tmp_path) -> None:
-    """Tests that the subtitle file is moved to the correct output path."""
+def test_write_output_moves_subtitle_to_target(tmp_path) -> None:
+    """Tests that `_write_output` moves the source to the resolved target path."""
     subtitle = tmp_path / "sub.srt"
     subtitle.touch()
-    output_path = tmp_path / "track.mp4"
 
-    result = _handle_subtitle_output(subtitle, output_path, "srt")
+    result = _write_output(
+        subtitle, tmp_path / "track.mp4", "srt", None, None, overwrite=False
+    )
 
     assert result == tmp_path / "track.srt"
     assert result.exists()
     assert not subtitle.exists()
+
+
+def test_write_output_unlinks_source_on_collision(tmp_path) -> None:
+    """Tests that a collision unlinks the source file before raising."""
+    subtitle = tmp_path / "sub.srt"
+    subtitle.touch()
+    existing = tmp_path / "track.srt"
+    existing.touch()
+
+    with pytest.raises(FileExistsError, match="already exists"):
+        _write_output(
+            subtitle, tmp_path / "track.mp4", "srt", None, None, overwrite=False
+        )
+
+    assert not subtitle.exists()
+    assert existing.exists()
+
+
+def test_write_output_overwrites_when_allowed(tmp_path) -> None:
+    """Tests that overwrite=True replaces an existing target."""
+    subtitle = tmp_path / "sub.srt"
+    subtitle.write_text("new")
+    existing = tmp_path / "track.srt"
+    existing.write_text("old")
+
+    result = _write_output(
+        subtitle, tmp_path / "track.mp4", "srt", None, None, overwrite=True
+    )
+
+    assert result.read_text() == "new"
 
 
 def test_validate_api_key_raises_without_key() -> None:
@@ -317,13 +348,14 @@ def test_validate_inputs_passes_on_valid_video(mocker, tmp_path) -> None:
     _validate_inputs(video, KoffeeConfig(embed="soft"))
 
 
-def test_handle_subtitle_output_audio_renames_subtitle(tmp_path) -> None:
-    """Tests that the subtitle file is moved correctly for audio inputs."""
+def test_write_output_audio_input_uses_audio_stem(tmp_path) -> None:
+    """Tests that `_write_output` derives the stem from an audio input."""
     subtitle = tmp_path / "sub.srt"
     subtitle.touch()
-    output_path = tmp_path / "track.mp3"
 
-    result = _handle_subtitle_output(subtitle, output_path, "srt")
+    result = _write_output(
+        subtitle, tmp_path / "track.mp3", "srt", None, None, overwrite=False
+    )
 
     assert result == tmp_path / "track.srt"
     assert result.exists()


### PR DESCRIPTION
Replaces four copies of the resolve-path + check-collision + move pattern (in `api._route_output`, `api._translate_subtitle_file`, `cli.transcribe`, `cli.convert`) with a single `_write_output` helper in `koffee.api`. The helper also cleans up the generated temp file on collision, making `api` consistent with the prior CLI behavior.