### PR TITLE
Add TranslationProvider protocol and per-backend text extraction

### DIFF
--- a/koffee/llm/_protocol.py
+++ b/koffee/llm/_protocol.py
@@ -1,0 +1,22 @@
+"""Structural contract for koffee LLM translation backends."""
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class TranslationProvider(Protocol):
+    """Module-level contract each backend in `koffee.llm` must satisfy."""
+
+    NAME: str
+    DEFAULT_MODEL: str
+
+    @staticmethod
+    def create_client(api_key: str | None) -> Any: ...
+
+    @staticmethod
+    def attempt_generate(
+        client: Any, prompt: str, model: str, system_prompt: str
+    ) -> tuple[Any, Exception | None]: ...
+
+    @staticmethod
+    def extract_text(response: Any) -> str: ...

--- a/koffee/llm/chatgpt.py
+++ b/koffee/llm/chatgpt.py
@@ -2,10 +2,18 @@
 
 from openai import APIConnectionError, APIStatusError, OpenAI, RateLimitError
 
+NAME = "chatgpt"
+DEFAULT_MODEL = "gpt-4o"
+
 
 def create_client(api_key: str | None):
     """Creates an OpenAI client."""
     return OpenAI(api_key=api_key)
+
+
+def extract_text(response) -> str:
+    """Extracts the generated text from a ChatGPT response."""
+    return response.choices[0].message.content
 
 
 def attempt_generate(client, prompt: str, model: str, system_prompt: str):

--- a/koffee/llm/claude.py
+++ b/koffee/llm/claude.py
@@ -2,10 +2,18 @@
 
 from anthropic import Anthropic, APIConnectionError, APIStatusError, RateLimitError
 
+NAME = "claude"
+DEFAULT_MODEL = "claude-sonnet-4-6"
+
 
 def create_client(api_key: str | None):
     """Creates an Anthropic client."""
     return Anthropic(api_key=api_key)
+
+
+def extract_text(response) -> str:
+    """Extracts the generated text from a Claude response."""
+    return response.content[0].text
 
 
 def attempt_generate(client, prompt: str, model: str, system_prompt: str):

--- a/koffee/llm/gemini.py
+++ b/koffee/llm/gemini.py
@@ -7,10 +7,18 @@ from google.genai.errors import APIError, ClientError
 
 log = logging.getLogger(__name__)
 
+NAME = "gemini"
+DEFAULT_MODEL = "gemini-2.5-flash"
+
 
 def create_client(api_key: str | None):
     """Creates a Gemini client."""
     return genai.Client(api_key=api_key)
+
+
+def extract_text(response) -> str:
+    """Extracts the generated text from a Gemini response."""
+    return response.text
 
 
 def attempt_generate(client, prompt: str, model: str, system_prompt: str):

--- a/koffee/llm/ollama.py
+++ b/koffee/llm/ollama.py
@@ -4,10 +4,18 @@ from openai import APIConnectionError, APIStatusError, OpenAI, RateLimitError
 
 OLLAMA_BASE_URL = "http://localhost:11434/v1"
 
+NAME = "ollama"
+DEFAULT_MODEL = "qwen3:14b"
+
 
 def create_client(api_key: str | None):
     """Creates an Ollama client using the local OpenAI-compatible endpoint."""
     return OpenAI(base_url=OLLAMA_BASE_URL, api_key="ollama")
+
+
+def extract_text(response) -> str:
+    """Extracts the generated text from an Ollama response."""
+    return response.choices[0].message.content
 
 
 def attempt_generate(client, prompt: str, model: str, system_prompt: str):

--- a/koffee/translator.py
+++ b/koffee/translator.py
@@ -5,6 +5,7 @@ import time
 from collections.abc import Callable
 from types import ModuleType
 
+from koffee.llm._protocol import TranslationProvider
 from koffee.utils import convert_to_timestamp
 
 log = logging.getLogger(__name__)
@@ -55,13 +56,6 @@ LLM = {
     "ollama": "koffee.llm.ollama",
 }
 
-DEFAULT_MODEL = {
-    "gemini": "gemini-2.5-flash",
-    "chatgpt": "gpt-4o",
-    "claude": "claude-sonnet-4-6",
-    "ollama": "qwen3:14b",
-}
-
 
 def translate(
     transcript: dict,
@@ -78,19 +72,18 @@ def translate(
     log.info(f"Translating transcript with {provider}.")
 
     system_prompt = prompt if prompt else SYSTEM_PROMPT
-    model = llm_model or DEFAULT_MODEL.get(provider, "")
+    backend = _load_backend(provider)
+    model = llm_model or backend.DEFAULT_MODEL
     resolved_chunk_size = chunk_size or CHUNK_SIZE_BY_MODEL.get(model, CHUNK_SIZE)
     resolved_context_size = (
         context_size
         if context_size is not None
         else CONTEXT_SIZE_BY_MODEL.get(model, CONTEXT_SIZE)
     )
-    backend = _load_backend(provider)
     client = backend.create_client(api_key)
     chunks = _chunk_segments(transcript, target_language, resolved_chunk_size)
     translated_segments = _translate_chunks(
         backend,
-        backend_name=provider,
         client=client,
         chunks=chunks,
         on_progress=on_progress,
@@ -101,7 +94,7 @@ def translate(
     return translated_segments
 
 
-def _load_backend(backend_name: str) -> ModuleType:
+def _load_backend(backend_name: str) -> TranslationProvider:
     """Loads a translation backend module by name."""
     import importlib  # noqa: PLC0415
 
@@ -114,17 +107,6 @@ def _load_backend(backend_name: str) -> ModuleType:
         raise ValueError(error_message)
 
     return importlib.import_module(module_path)
-
-
-def _extract_text(response, backend_name: str) -> str:
-    """Extracts text content from a backend-specific response object."""
-    if backend_name == "gemini":
-        return response.text
-    if backend_name in ("chatgpt", "ollama"):
-        return response.choices[0].message.content
-    if backend_name == "claude":
-        return response.content[0].text
-    return str(response)
 
 
 def _chunk_segments(
@@ -149,7 +131,6 @@ def _chunk_segments(
 
 def _translate_chunks(
     backend: ModuleType,
-    backend_name: str,
     client,
     chunks: list[dict],
     on_progress: Callable[[float], None] | None,
@@ -168,7 +149,6 @@ def _translate_chunks(
         )
         translated_chunk = _translate_chunk(
             backend,
-            backend_name,
             client,
             prompt,
             chunk_data["chunk"],
@@ -188,7 +168,6 @@ def _translate_chunks(
 
 def _translate_chunk(
     backend: ModuleType,
-    backend_name: str,
     client,
     prompt: str,
     chunk: list[dict],
@@ -197,7 +176,7 @@ def _translate_chunk(
 ) -> list[dict]:
     """Calls the LLM with a prompt and parses the response."""
     response = _call_with_retries(backend, client, prompt, llm_model, system_prompt)
-    response_text = _extract_text(response, backend_name)
+    response_text = backend.extract_text(response)
     translated_chunk = _parse_srt_response(response_text, chunk)
 
     return translated_chunk

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -14,7 +14,6 @@ from koffee.translator import (
     _build_prompt,
     _call_with_retries,
     _chunk_segments,
-    _extract_text,
     _load_backend,
     _parse_srt_response,
     _sanitize_response,
@@ -374,33 +373,33 @@ def test_load_backend_gemini() -> None:
     assert hasattr(backend, "attempt_generate")
 
 
-def test_extract_text_gemini() -> None:
+def test_gemini_extract_text() -> None:
     """Tests that text is extracted from a Gemini response."""
     from unittest.mock import MagicMock  # noqa: PLC0415
 
     response = MagicMock()
     response.text = "Hello."
-    assert _extract_text(response, "gemini") == "Hello."
+    assert gemini.extract_text(response) == "Hello."
 
 
-def test_extract_text_chatgpt() -> None:
+def test_chatgpt_extract_text() -> None:
     """Tests that text is extracted from a ChatGPT response."""
     from unittest.mock import MagicMock  # noqa: PLC0415
 
     response = MagicMock()
     response.choices = [MagicMock()]
     response.choices[0].message.content = "Hello."
-    assert _extract_text(response, "chatgpt") == "Hello."
+    assert chatgpt.extract_text(response) == "Hello."
 
 
-def test_extract_text_claude() -> None:
+def test_claude_extract_text() -> None:
     """Tests that text is extracted from a Claude response."""
     from unittest.mock import MagicMock  # noqa: PLC0415
 
     response = MagicMock()
     response.content = [MagicMock()]
     response.content[0].text = "Hello."
-    assert _extract_text(response, "claude") == "Hello."
+    assert claude.extract_text(response) == "Hello."
 
 
 def test_translate_uses_default_model(mocker: MockerFixture) -> None:
@@ -602,14 +601,14 @@ def test_load_backend_ollama() -> None:
     assert hasattr(backend, "attempt_generate")
 
 
-def test_extract_text_ollama() -> None:
+def test_ollama_extract_text() -> None:
     """Tests that text is extracted from an Ollama response."""
     from unittest.mock import MagicMock  # noqa: PLC0415
 
     response = MagicMock()
     response.choices = [MagicMock()]
     response.choices[0].message.content = "Hello."
-    assert _extract_text(response, "ollama") == "Hello."
+    assert ollama.extract_text(response) == "Hello."
 
 
 def test_claude_translate(mocker: MockerFixture) -> None:


### PR DESCRIPTION
Formalizes the LLM backend contract as a `TranslationProvider` Protocol in `koffee/llm/_protocol.py`. Each backend module now owns its `NAME`, `DEFAULT_MODEL`, and `extract_text` implementation, letting the translator dispatch via `backend.extract_text(response)` instead of a central if/elif chain and making the central `DEFAULT_MODEL` dict redundant.