### PR TITLE
Expand pre-flight input validation

### DIFF
--- a/koffee/api.py
+++ b/koffee/api.py
@@ -113,6 +113,7 @@ def _validate_inputs(video_file_path: Path | str, config: KoffeeConfig) -> None:
             raise IncompatibleOptionsError(error_message)
 
     _validate_api_key(config)
+    _validate_output_path(video_file_path, config)
 
 
 def _validate_api_key(config: KoffeeConfig) -> None:
@@ -124,6 +125,24 @@ def _validate_api_key(config: KoffeeConfig) -> None:
             "environment variable."
         )
         raise ValueError(error_message)
+
+
+def _validate_output_path(video_file_path: Path | str, config: KoffeeConfig) -> None:
+    """Ensures the resolved output path is writable and not already occupied."""
+    input_suffix = Path(video_file_path).suffix.lower()
+    is_video = input_suffix in VIDEO_EXTENSIONS
+    has_embed = (
+        is_video and not config.use_embedded_subtitles and config.embed != "none"
+    )
+
+    base_path = _get_output_path(
+        video_file_path, config.output_dir, config.output_name, date_suffix=has_embed
+    )
+    output_path = (
+        base_path if has_embed else base_path.with_suffix(f".{config.subtitle_format}")
+    )
+
+    _check_output_collision(output_path, config.overwrite)
 
 
 def _apply_config_overrides(config: KoffeeConfig | None, kwargs: dict) -> KoffeeConfig:

--- a/koffee/data/config.py
+++ b/koffee/data/config.py
@@ -193,6 +193,15 @@ class KoffeeConfig(BaseModel):
             raise ValueError(error_message)
         return value
 
+    @field_validator("chunk_size", "context_size")
+    @classmethod
+    def _validate_positive_size(cls, value: int | None) -> int | None:
+        """Rejects non-positive chunk/context sizes that would stall translation."""
+        if value is not None and value <= 0:
+            error_message = f"Size must be a positive integer, got {value}."
+            raise ValueError(error_message)
+        return value
+
 
 def load_config_file(path: Path | None = None) -> dict:
     """Loads config from a TOML file, searching default paths if none given.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,7 @@
 """Tests for the koffee API."""
 
 import importlib
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -346,6 +347,50 @@ def test_validate_inputs_passes_on_valid_video(mocker, tmp_path) -> None:
     mocker.patch("koffee.api.shutil.which", return_value="/usr/bin/ffmpeg")
 
     _validate_inputs(video, KoffeeConfig(embed="soft"))
+
+
+def test_validate_inputs_rejects_existing_output(tmp_path) -> None:
+    """Tests that an existing output file raises FileExistsError upfront."""
+    audio = tmp_path / "track.mp3"
+    audio.touch()
+    existing_output = tmp_path / "track.vtt"
+    existing_output.touch()
+
+    with pytest.raises(FileExistsError, match="Output file already exists"):
+        _validate_inputs(audio, KoffeeConfig())
+
+
+def test_validate_inputs_allows_existing_output_with_overwrite(tmp_path) -> None:
+    """Tests that an existing output is tolerated when overwrite is enabled."""
+    audio = tmp_path / "track.mp3"
+    audio.touch()
+    existing_output = tmp_path / "track.vtt"
+    existing_output.touch()
+
+    _validate_inputs(audio, KoffeeConfig(overwrite=True))
+
+
+def test_validate_inputs_creates_missing_output_dir(tmp_path) -> None:
+    """Tests that a missing output_dir is created during validation."""
+    audio = tmp_path / "track.mp3"
+    audio.touch()
+    new_dir = tmp_path / "nested" / "out"
+
+    _validate_inputs(audio, KoffeeConfig(output_dir=new_dir))
+
+    assert new_dir.is_dir()
+
+
+def test_validate_inputs_embed_checks_video_suffix_collision(mocker, tmp_path) -> None:
+    """Tests that embed mode checks for collision against the video-suffix output."""
+    video = tmp_path / "clip.mp4"
+    video.touch()
+    mocker.patch("koffee.api.shutil.which", return_value="/usr/bin/ffmpeg")
+    colliding = tmp_path / f"clip_{datetime.now().strftime('%m-%d-%Y')}.mp4"
+    colliding.touch()
+
+    with pytest.raises(FileExistsError, match="Output file already exists"):
+        _validate_inputs(video, KoffeeConfig(embed="soft"))
 
 
 def test_write_output_audio_input_uses_audio_stem(tmp_path) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -81,6 +81,22 @@ def test_valid_whisper_model_is_accepted() -> None:
     assert config.whisper_model == "tiny"
 
 
+def test_non_positive_chunk_size_raises() -> None:
+    """Tests that a zero or negative chunk_size raises a validation error."""
+    with pytest.raises(ValueError, match="Size must be a positive integer"):
+        KoffeeConfig(chunk_size=0)
+    with pytest.raises(ValueError, match="Size must be a positive integer"):
+        KoffeeConfig(chunk_size=-5)
+
+
+def test_non_positive_context_size_raises() -> None:
+    """Tests that a zero or negative context_size raises a validation error."""
+    with pytest.raises(ValueError, match="Size must be a positive integer"):
+        KoffeeConfig(context_size=0)
+    with pytest.raises(ValueError, match="Size must be a positive integer"):
+        KoffeeConfig(context_size=-3)
+
+
 def test_api_key_falls_back_to_google_env_var(monkeypatch) -> None:
     """Tests that api_key falls back to GOOGLE_API_KEY for gemini backend."""
     monkeypatch.setenv("GOOGLE_API_KEY", "env-key-123")


### PR DESCRIPTION
## Summary
Extends `_validate_inputs` to fail up-front on two more classes of bad state: an output path that already exists (without `--overwrite`) or whose parent directory isn't writable, and non-positive `chunk_size` / `context_size` values that would stall translation. Both previously surfaced only after minutes of ASR work.