### PR TITLE
Make sleep between LLM requests configurable

### DIFF
--- a/koffee/api.py
+++ b/koffee/api.py
@@ -266,6 +266,7 @@ def _translate_subtitle_file(
         llm_model=config.llm_model,
         prompt=config.prompt,
         provider=config.provider,
+        sleep_requests=config.sleep_requests,
     )
     translated_path = generate_subtitles(config.subtitle_format, translated_segments)
     output_subtitle_path = _write_output(
@@ -325,6 +326,7 @@ def _get_segments(
             provider=config.provider,
             chunk_size=config.chunk_size,
             context_size=config.context_size,
+            sleep_requests=config.sleep_requests,
         )
 
     return segments

--- a/koffee/cli.py
+++ b/koffee/cli.py
@@ -113,6 +113,7 @@ def cli(
     llm_model: Annotated[str, Parameter(name=("--llm-model",))] | None = None,
     chunk_size: Annotated[int, Parameter(name=("--chunk-size",))] | None = None,
     context_size: Annotated[int, Parameter(name=("--context-size",))] | None = None,
+    sleep_requests: Annotated[int, Parameter(name=("--sleep-requests",))] | None = None,
     prompt: Annotated[str, Parameter(name=("--prompt",))] | None = None,
     api_key: Annotated[str, Parameter(name=("--api-key",))] | None = None,
     config: Annotated[Path, Parameter(name=("--config",), group=options_group)]
@@ -187,6 +188,7 @@ def cli(
         "llm_model": llm_model,
         "chunk_size": chunk_size,
         "context_size": context_size,
+        "sleep_requests": sleep_requests,
         "overwrite": overwrite,
         "output_dir": output_dir,
         "output_name": output_name,

--- a/koffee/data/config.py
+++ b/koffee/data/config.py
@@ -143,6 +143,7 @@ class KoffeeConfig(BaseModel):
     llm_model: str | None = None
     chunk_size: int | None = None
     context_size: int | None = None
+    sleep_requests: int | None = None
     prompt: str | None = None
     dry_run: bool = False
     overwrite: bool = False
@@ -199,6 +200,15 @@ class KoffeeConfig(BaseModel):
         """Rejects non-positive chunk/context sizes that would stall translation."""
         if value is not None and value <= 0:
             error_message = f"Size must be a positive integer, got {value}."
+            raise ValueError(error_message)
+        return value
+
+    @field_validator("sleep_requests")
+    @classmethod
+    def _validate_sleep_requests(cls, value: int | None) -> int | None:
+        """Rejects negative sleep durations; zero is valid for no delay."""
+        if value is not None and value < 0:
+            error_message = f"sleep_requests must be non-negative, got {value}."
             raise ValueError(error_message)
         return value
 

--- a/koffee/translator.py
+++ b/koffee/translator.py
@@ -12,7 +12,11 @@ log = logging.getLogger(__name__)
 
 CHUNK_SIZE = 200
 CONTEXT_SIZE = 20
-SLEEP_BETWEEN_REQUESTS = 4
+SLEEP_REQUESTS = 4
+
+SLEEP_REQUESTS_BY_PROVIDER: dict[str, int] = {
+    "ollama": 0,
+}
 
 CHUNK_SIZE_BY_MODEL: dict[str, int] = {
     "qwen3:8b": 40,
@@ -67,6 +71,7 @@ def translate(
     provider: str = "gemini",
     chunk_size: int | None = None,
     context_size: int | None = None,
+    sleep_requests: int | None = None,
 ) -> list:
     """Translates a transcript using an LLM backend, preserving timing information."""
     log.info(f"Translating transcript with {provider}.")
@@ -80,6 +85,11 @@ def translate(
         if context_size is not None
         else CONTEXT_SIZE_BY_MODEL.get(model, CONTEXT_SIZE)
     )
+    resolved_sleep_requests = (
+        sleep_requests
+        if sleep_requests is not None
+        else SLEEP_REQUESTS_BY_PROVIDER.get(provider, SLEEP_REQUESTS)
+    )
     client = backend.create_client(api_key)
     chunks = _chunk_segments(transcript, target_language, resolved_chunk_size)
     translated_segments = _translate_chunks(
@@ -90,6 +100,7 @@ def translate(
         llm_model=model,
         system_prompt=system_prompt,
         context_size=resolved_context_size,
+        sleep_requests=resolved_sleep_requests,
     )
     return translated_segments
 
@@ -137,6 +148,7 @@ def _translate_chunks(
     llm_model: str,
     system_prompt: str,
     context_size: int = CONTEXT_SIZE,
+    sleep_requests: int = SLEEP_REQUESTS,
 ) -> list[dict]:
     """Iterates chunks, translating each and reporting progress."""
     log.info(f"Translating in {len(chunks)} chunks.")
@@ -160,8 +172,8 @@ def _translate_chunks(
         if on_progress:
             on_progress((i + 1) / len(chunks))
 
-        if i < len(chunks) - 1:
-            time.sleep(SLEEP_BETWEEN_REQUESTS)
+        if i < len(chunks) - 1 and sleep_requests > 0:
+            time.sleep(sleep_requests)
 
     return translated_segments
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -115,6 +115,7 @@ def test_get_segments_non_whisper_calls_translate(mocker, api_module) -> None:
     config.llm_model = "gemini-2.5-flash"
     config.chunk_size = None
     config.context_size = None
+    config.sleep_requests = None
     config.prompt = None
     transcript = {"segments": [], "language": "ko"}
 
@@ -131,6 +132,7 @@ def test_get_segments_non_whisper_calls_translate(mocker, api_module) -> None:
         provider=config.provider,
         chunk_size=config.chunk_size,
         context_size=config.context_size,
+        sleep_requests=config.sleep_requests,
     )
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -97,6 +97,18 @@ def test_non_positive_context_size_raises() -> None:
         KoffeeConfig(context_size=-3)
 
 
+def test_zero_sleep_requests_is_accepted() -> None:
+    """Tests that sleep_requests=0 is a valid no-delay setting."""
+    config = KoffeeConfig(sleep_requests=0)
+    assert config.sleep_requests == 0
+
+
+def test_negative_sleep_requests_raises() -> None:
+    """Tests that a negative sleep_requests raises a validation error."""
+    with pytest.raises(ValueError, match="sleep_requests must be non-negative"):
+        KoffeeConfig(sleep_requests=-1)
+
+
 def test_api_key_falls_back_to_google_env_var(monkeypatch) -> None:
     """Tests that api_key falls back to GOOGLE_API_KEY for gemini backend."""
     monkeypatch.setenv("GOOGLE_API_KEY", "env-key-123")

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -148,6 +148,60 @@ def test_translate_sleeps_between_chunks(mocker: MockerFixture) -> None:
 
     # 2 segments with chunk size 1 = 2 chunks, sleep called once (not after last chunk)
     assert mock_sleep.call_count == 1
+    assert mock_sleep.call_args.args[0] == 4
+
+
+def test_translate_skips_sleep_when_zero(mocker: MockerFixture) -> None:
+    """Tests that sleep_requests=0 skips time.sleep between chunks entirely."""
+    mock_client = mocker.MagicMock()
+    mocker.patch.object(gemini, "create_client", return_value=mock_client)
+    mock_sleep = mocker.patch("koffee.translator.time.sleep")
+    mocker.patch("koffee.translator.CHUNK_SIZE", 1)
+    mock_client.models.generate_content.return_value.text = (
+        "1\n00:00:00,000 --> 00:00:06,360\nHello."
+    )
+
+    translate(
+        SAMPLE_TRANSCRIPT, "en", api_key=None, provider="gemini", sleep_requests=0
+    )
+
+    assert mock_sleep.call_count == 0
+
+
+def test_translate_ollama_defaults_to_no_sleep(mocker: MockerFixture) -> None:
+    """Tests that the ollama provider uses zero sleep by default."""
+    mock_client = mocker.MagicMock()
+    mocker.patch("koffee.llm.ollama.create_client", return_value=mock_client)
+    mock_sleep = mocker.patch("koffee.translator.time.sleep")
+    mocker.patch("koffee.translator.CHUNK_SIZE", 1)
+    mock_client.chat.completions.create.return_value.choices = [
+        mocker.MagicMock(
+            message=mocker.MagicMock(
+                content=("1\n00:00:00,000 --> 00:00:06,360\nHello.")
+            )
+        )
+    ]
+
+    translate(SAMPLE_TRANSCRIPT, "en", api_key=None, provider="ollama")
+
+    assert mock_sleep.call_count == 0
+
+
+def test_translate_explicit_sleep_overrides_default(mocker: MockerFixture) -> None:
+    """Tests that an explicit sleep_requests value overrides the provider default."""
+    mock_client = mocker.MagicMock()
+    mocker.patch.object(gemini, "create_client", return_value=mock_client)
+    mock_sleep = mocker.patch("koffee.translator.time.sleep")
+    mocker.patch("koffee.translator.CHUNK_SIZE", 1)
+    mock_client.models.generate_content.return_value.text = (
+        "1\n00:00:00,000 --> 00:00:06,360\nHello."
+    )
+
+    translate(
+        SAMPLE_TRANSCRIPT, "en", api_key=None, provider="gemini", sleep_requests=9
+    )
+
+    assert mock_sleep.call_args.args[0] == 9
 
 
 def test_translate_passes_api_key(mocker: MockerFixture) -> None:


### PR DESCRIPTION
## Summary
Exposes `sleep_requests` as a config field and `--sleep-requests` CLI flag controlling the delay between chunked LLM requests in `translate()`. Defaults are provider-aware (`0` for ollama, `4` for cloud providers), and a value of `0` skips the sleep syscall entirely.