### PR TITLE
Add TypedDicts for transcript, segment, and chunk shapes

### DIFF
--- a/koffee/api.py
+++ b/koffee/api.py
@@ -16,6 +16,7 @@ from koffee.exceptions import (
     UnsupportedFileError,
 )
 from koffee.schemas.config import KoffeeConfig
+from koffee.schemas.types import Segment, Transcript
 from koffee.subtitle import generate_subtitles
 from koffee.translator import translate
 from koffee.utils import (
@@ -159,7 +160,7 @@ def _transcribe(
     video_file_path: Path | str,
     config: KoffeeConfig,
     on_progress: Callable[[float], None] | None,
-) -> dict:
+) -> Transcript:
     """Transcribes audio from the file, returning the raw transcript."""
     transcript = transcribe(
         str(video_file_path),
@@ -175,7 +176,7 @@ def _transcribe(
 
 
 def _translate(
-    transcript: dict,
+    transcript: Transcript,
     config: KoffeeConfig,
     on_progress: Callable[[float], None] | None,
 ) -> Path:
@@ -308,10 +309,10 @@ def _get_output_path(
 
 
 def _get_segments(
-    transcript: dict,
+    transcript: Transcript,
     config: KoffeeConfig,
     on_progress: Callable[[float], None] | None = None,
-) -> list:
+) -> list[Segment]:
     """Returns translated or raw segments based on the translation backend."""
     if config.provider == "whisper":
         segments = transcript["segments"]

--- a/koffee/asr.py
+++ b/koffee/asr.py
@@ -3,10 +3,10 @@
 import logging
 from collections.abc import Callable
 from dataclasses import asdict
-from typing import Any
 
 from faster_whisper import WhisperModel
 
+from koffee.schemas.types import Segment, Transcript
 from koffee.utils import get_video_duration
 
 log = logging.getLogger(__name__)
@@ -20,7 +20,7 @@ def transcribe(
     provider: str,
     on_progress: Callable[[float], None] | None = None,
     vad_filter: bool = True,
-) -> dict:
+) -> Transcript:
     """Transcribes a video or audio file."""
     log.info("Transcribing file.")
 
@@ -61,7 +61,7 @@ def _run_transcription(
 
 def _consume_segments(
     segments, video_file: str, on_progress: Callable[[float], None] | None
-) -> list[dict[str, Any]]:
+) -> list[Segment]:
     """Consumes the segment generator, reporting progress as each segment is yielded."""
     duration = get_video_duration(video_file) if on_progress else None
     result = []

--- a/koffee/schemas/types.py
+++ b/koffee/schemas/types.py
@@ -1,0 +1,27 @@
+"""Type definitions for transcript, segment, and chunk shapes."""
+
+from typing import TypedDict
+
+
+class Segment(TypedDict):
+    """A single subtitle segment with timing and text."""
+
+    start: float
+    end: float
+    text: str
+
+
+class Transcript(TypedDict):
+    """A transcript produced by ASR or parsed from a subtitle file."""
+
+    segments: list[Segment]
+    language: str
+
+
+class Chunk(TypedDict):
+    """A prompt-ready slice of a transcript for a single LLM call."""
+
+    chunk: list[Segment]
+    source_language: str
+    target_language: str
+    start_entry: int

--- a/koffee/subtitle.py
+++ b/koffee/subtitle.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 from koffee.exceptions import InvalidSubtitleFormatError
+from koffee.schemas.types import Segment
 from koffee.utils import (
     convert_segments_to_ass,
     convert_segments_to_srt,
@@ -12,7 +13,7 @@ from koffee.utils import (
 
 def generate_subtitles(
     subtitle_format: str,
-    segments: list,
+    segments: list[Segment],
     output_dir: Path | None = None,
 ) -> Path:
     """Generates subtitles from a list of segments."""

--- a/koffee/translator.py
+++ b/koffee/translator.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from types import ModuleType
 
 from koffee.llm._protocol import TranslationProvider
+from koffee.schemas.types import Chunk, Segment, Transcript
 from koffee.utils import convert_to_timestamp, with_retries
 
 log = logging.getLogger(__name__)
@@ -62,7 +63,7 @@ LLM = {
 
 
 def translate(
-    transcript: dict,
+    transcript: Transcript,
     target_language: str,
     api_key: str | None,
     on_progress: Callable[[float], None] | None = None,
@@ -72,7 +73,7 @@ def translate(
     chunk_size: int | None = None,
     context_size: int | None = None,
     sleep_requests: int | None = None,
-) -> list:
+) -> list[Segment]:
     """Translates a transcript using an LLM backend, preserving timing information."""
     log.info(f"Translating transcript with {provider}.")
 
@@ -121,8 +122,8 @@ def _load_backend(backend_name: str) -> TranslationProvider:
 
 
 def _chunk_segments(
-    transcript: dict, target_language: str, chunk_size: int = CHUNK_SIZE
-) -> list[dict]:
+    transcript: Transcript, target_language: str, chunk_size: int = CHUNK_SIZE
+) -> list[Chunk]:
     """Splits transcript segments into prompt-ready chunks."""
     segments = transcript["segments"]
     source_language = transcript["language"]
@@ -143,13 +144,13 @@ def _chunk_segments(
 def _translate_chunks(
     backend: ModuleType,
     client,
-    chunks: list[dict],
+    chunks: list[Chunk],
     on_progress: Callable[[float], None] | None,
     llm_model: str,
     system_prompt: str,
     context_size: int = CONTEXT_SIZE,
     sleep_requests: int = SLEEP_REQUESTS,
-) -> list[dict]:
+) -> list[Segment]:
     """Iterates chunks, translating each and reporting progress."""
     log.info(f"Translating in {len(chunks)} chunks.")
 
@@ -182,10 +183,10 @@ def _translate_chunk(
     backend: ModuleType,
     client,
     prompt: str,
-    chunk: list[dict],
+    chunk: list[Segment],
     llm_model: str,
     system_prompt: str,
-) -> list[dict]:
+) -> list[Segment]:
     """Calls the LLM with a prompt and parses the response."""
     response = _call_with_retries(backend, client, prompt, llm_model, system_prompt)
     response_text = backend.extract_text(response)
@@ -210,7 +211,7 @@ def _call_with_retries(
     )
 
 
-def _segments_to_srt(segments: list[dict]) -> str:
+def _segments_to_srt(segments: list[Segment]) -> str:
     """Converts a list of segments to SRT format string."""
     lines = []
     for i, seg in enumerate(segments, 1):
@@ -248,8 +249,8 @@ def _sanitize_response(response_text: str | None) -> str:
 
 
 def _parse_srt_response(
-    response_text: str | None, original_segments: list[dict]
-) -> list[dict]:
+    response_text: str | None, original_segments: list[Segment]
+) -> list[Segment]:
     """Parses SRT formatted response back into segments.
 
     Matches blocks to original segments by entry number rather than position,
@@ -289,8 +290,8 @@ def _blocks_to_translation_map(blocks: list[str]) -> dict[int, str]:
 
 
 def _merge_translated_segments(
-    translation_map: dict[int, str], original_segments: list[dict]
-) -> list[dict]:
+    translation_map: dict[int, str], original_segments: list[Segment]
+) -> list[Segment]:
     """Merges translated text onto original segments."""
     merged_segments = []
     for i, original in enumerate(original_segments, start=1):
@@ -310,8 +311,8 @@ def _merge_translated_segments(
 
 
 def _build_prompt(
-    chunk: list[dict],
-    context_segments: list[dict],
+    chunk: list[Segment],
+    context_segments: list[Segment],
     source_language: str,
     target_language: str,
     start_entry: int,

--- a/koffee/utils/ass_converter.py
+++ b/koffee/utils/ass_converter.py
@@ -4,6 +4,7 @@ import logging
 import uuid
 from pathlib import Path
 
+from koffee.schemas.types import Segment
 from koffee.utils.timestamp_converter import convert_to_timestamp
 
 log = logging.getLogger(__name__)
@@ -40,7 +41,7 @@ ASS_HEADER = (
 )
 
 
-def convert_segments_to_ass(segments: list, output_dir: Path) -> Path:
+def convert_segments_to_ass(segments: list[Segment], output_dir: Path) -> Path:
     """Converts segments to ASS format."""
     log.debug("Converting segments to ASS format.")
 

--- a/koffee/utils/srt_converter.py
+++ b/koffee/utils/srt_converter.py
@@ -4,12 +4,13 @@ import logging
 import uuid
 from pathlib import Path
 
+from koffee.schemas.types import Segment
 from koffee.utils.timestamp_converter import convert_to_timestamp
 
 log = logging.getLogger(__name__)
 
 
-def convert_segments_to_srt(segments: list, output_dir: Path) -> Path:
+def convert_segments_to_srt(segments: list[Segment], output_dir: Path) -> Path:
     """Converts segments to SRT format."""
     log.debug("Converting segments to SRT format.")
 

--- a/koffee/utils/subtitle_parser.py
+++ b/koffee/utils/subtitle_parser.py
@@ -4,6 +4,8 @@ import logging
 import re
 from pathlib import Path
 
+from koffee.schemas.types import Segment
+
 log = logging.getLogger(__name__)
 
 TIMESTAMP_PATTERN = re.compile(
@@ -19,7 +21,7 @@ ASS_DIALOGUE_PATTERN = re.compile(
 )
 
 
-def parse_subtitle_file(file_path: Path | str) -> list[dict]:
+def parse_subtitle_file(file_path: Path | str) -> list[Segment]:
     """Parses an SRT, VTT, or ASS/SSA file into a list of segment dicts."""
     file_path = Path(file_path)
     text = file_path.read_text(encoding="utf-8")
@@ -53,7 +55,7 @@ def parse_subtitle_file(file_path: Path | str) -> list[dict]:
     return segments
 
 
-def _parse_ass(text: str, file_path: Path) -> list[dict]:
+def _parse_ass(text: str, file_path: Path) -> list[Segment]:
     """Parses ASS/SSA formatted text into segment dicts."""
     segments = []
     for line in text.splitlines():

--- a/koffee/utils/vtt_converter.py
+++ b/koffee/utils/vtt_converter.py
@@ -4,12 +4,13 @@ import logging
 import uuid
 from pathlib import Path
 
+from koffee.schemas.types import Segment
 from koffee.utils.timestamp_converter import convert_to_timestamp
 
 log = logging.getLogger(__name__)
 
 
-def convert_segments_to_vtt(segments: list, output_dir: Path) -> Path:
+def convert_segments_to_vtt(segments: list[Segment], output_dir: Path) -> Path:
     """Converts segments to VTT format."""
     log.debug("Converting segments to VTT format.")
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -26,6 +26,7 @@ from koffee.exceptions import (
     UnsupportedFileError,
 )
 from koffee.schemas.config import KoffeeConfig
+from koffee.schemas.types import Transcript
 
 
 @pytest.fixture
@@ -95,7 +96,10 @@ def test_get_segments_whisper_returns_raw(mocker, api_module) -> None:
     mock_translate = mocker.patch.object(api_module, "translate")
     config = MagicMock(spec=KoffeeConfig)
     config.provider = "whisper"
-    transcript = {"segments": [{"start": 0.0, "end": 1.0, "text": "hi"}]}
+    transcript: Transcript = {
+        "segments": [{"start": 0.0, "end": 1.0, "text": "hi"}],
+        "language": "en",
+    }
 
     result = _get_segments(transcript, config)
 
@@ -117,7 +121,7 @@ def test_get_segments_non_whisper_calls_translate(mocker, api_module) -> None:
     config.context_size = None
     config.sleep_requests = None
     config.prompt = None
-    transcript = {"segments": [], "language": "ko"}
+    transcript: Transcript = {"segments": [], "language": "ko"}
 
     result = _get_segments(transcript, config)
 

--- a/tests/test_subtitle.py
+++ b/tests/test_subtitle.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from koffee.exceptions import InvalidSubtitleFormatError
+from koffee.schemas.types import Segment
 from koffee.subtitle import generate_subtitles
 
 
@@ -24,7 +25,7 @@ def test_subtitle_generator(
     output_dir: Path,
 ) -> None:
     """Tests that the text is converted to the correct subtitle format."""
-    text = [
+    text: list[Segment] = [
         {
             "start": 0.0,
             "end": 6.28,
@@ -112,7 +113,7 @@ On the other side, a virgin approached and opened a window in front of the Shimm
 @pytest.mark.parametrize("subtitle_format", ["csv", "pdf", "txt"])
 def test_invalid_format(subtitle_format: str) -> None:
     """Tests that the appropriate error is raised when an invalid format is given."""
-    sample_text = [{"start": 10.5, "end": 15.0, "text": "Hello, world!"}]
+    sample_text: list[Segment] = [{"start": 10.5, "end": 15.0, "text": "Hello, world!"}]
 
     error_message = f"Invalid or unsupported subtitle format: {subtitle_format}"
     with pytest.raises(InvalidSubtitleFormatError, match=error_message):

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -5,6 +5,7 @@ from google.genai.errors import APIError, ClientError
 from pytest_mock import MockerFixture
 
 from koffee.llm import chatgpt, claude, gemini, ollama
+from koffee.schemas.types import Segment, Transcript
 from koffee.translator import (
     CHUNK_SIZE,
     CHUNK_SIZE_BY_MODEL,
@@ -20,7 +21,7 @@ from koffee.translator import (
     translate,
 )
 
-SAMPLE_SEGMENTS = [
+SAMPLE_SEGMENTS: list[Segment] = [
     {"start": 0.0, "end": 6.36, "text": "안녕하세요."},
     {"start": 7.8, "end": 10.74, "text": "잘 지내셨어요?"},
 ]
@@ -30,7 +31,7 @@ SAMPLE_SRT_RESPONSE = (
     "2\n00:00:07,800 --> 00:00:10,740\nHow have you been?"
 )
 
-SAMPLE_TRANSCRIPT = {
+SAMPLE_TRANSCRIPT: Transcript = {
     "segments": SAMPLE_SEGMENTS,
     "language": "ko",
 }
@@ -38,7 +39,9 @@ SAMPLE_TRANSCRIPT = {
 
 def test_build_prompt_with_context() -> None:
     """Tests that the prompt includes context section when they are provided."""
-    context = [{"start": 0.0, "end": 1.0, "text": "시대를 초월하는 마음."}]
+    context: list[Segment] = [
+        {"start": 0.0, "end": 1.0, "text": "시대를 초월하는 마음."}
+    ]
 
     result = _build_prompt(
         chunk=SAMPLE_SEGMENTS,
@@ -811,11 +814,11 @@ def test_ollama_translate_uses_default_model(mocker: MockerFixture) -> None:
 
 def test_chunk_segments_default_chunk_size() -> None:
     """Tests that _chunk_segments uses CHUNK_SIZE when no chunk_size is given."""
-    many_segments = [
+    many_segments: list[Segment] = [
         {"start": float(i), "end": float(i + 1), "text": "x"}
         for i in range(CHUNK_SIZE + 1)
     ]
-    transcript = {"segments": many_segments, "language": "ja"}
+    transcript: Transcript = {"segments": many_segments, "language": "ja"}
 
     chunks = _chunk_segments(transcript, "ko")
 
@@ -826,10 +829,10 @@ def test_chunk_segments_default_chunk_size() -> None:
 
 def test_chunk_segments_explicit_chunk_size() -> None:
     """Tests that _chunk_segments respects an explicit chunk_size argument."""
-    segments = [
+    segments: list[Segment] = [
         {"start": float(i), "end": float(i + 1), "text": "x"} for i in range(10)
     ]
-    transcript = {"segments": segments, "language": "ja"}
+    transcript: Transcript = {"segments": segments, "language": "ja"}
 
     chunks = _chunk_segments(transcript, "ko", chunk_size=3)
 
@@ -846,7 +849,7 @@ def test_translate_uses_model_chunk_size(mocker: MockerFixture) -> None:
 
     model = "qwen3:14b"
     expected_chunk_size = CHUNK_SIZE_BY_MODEL[model]
-    many_segments = [
+    many_segments: list[Segment] = [
         {"start": float(i), "end": float(i + 1), "text": "x"}
         for i in range(expected_chunk_size + 1)
     ]
@@ -860,7 +863,7 @@ def test_translate_uses_model_chunk_size(mocker: MockerFixture) -> None:
     mock_client.chat.completions.create.return_value = mock_response
 
     translate(
-        {"segments": many_segments, "language": "ja"},
+        Transcript(segments=many_segments, language="ja"),
         "ko",
         api_key=None,
         provider="ollama",
@@ -878,7 +881,9 @@ def test_translate_explicit_chunk_size_overrides_model_default(
     mocker.patch.object(ollama, "create_client", return_value=mock_client)
     mocker.patch("koffee.translator.time.sleep")
 
-    segments = [{"start": float(i), "end": float(i + 1), "text": "x"} for i in range(5)]
+    segments: list[Segment] = [
+        {"start": float(i), "end": float(i + 1), "text": "x"} for i in range(5)
+    ]
     mock_response = mocker.MagicMock()
     mock_response.choices = [mocker.MagicMock()]
     mock_response.choices[0].message.content = "\n\n".join(
@@ -887,7 +892,7 @@ def test_translate_explicit_chunk_size_overrides_model_default(
     mock_client.chat.completions.create.return_value = mock_response
 
     translate(
-        {"segments": segments, "language": "ja"},
+        Transcript(segments=segments, language="ja"),
         "ko",
         api_key=None,
         provider="ollama",
@@ -911,7 +916,9 @@ def test_translate_uses_model_context_size(mocker: MockerFixture) -> None:
     model = "qwen3:14b"
     expected_context = CONTEXT_SIZE_BY_MODEL[model]
 
-    segments = [{"start": float(i), "end": float(i + 1), "text": "x"} for i in range(3)]
+    segments: list[Segment] = [
+        {"start": float(i), "end": float(i + 1), "text": "x"} for i in range(3)
+    ]
     mock_response = mocker.MagicMock()
     mock_response.choices = [mocker.MagicMock()]
     mock_response.choices[0].message.content = "\n\n".join(
@@ -922,7 +929,7 @@ def test_translate_uses_model_context_size(mocker: MockerFixture) -> None:
     mock_build = mocker.patch("koffee.translator._build_prompt", return_value="prompt")
 
     translate(
-        {"segments": segments, "language": "ja"},
+        Transcript(segments=segments, language="ja"),
         "ko",
         api_key=None,
         provider="ollama",


### PR DESCRIPTION
## Summary
Replaces loose `dict` / `list[dict]` annotations with `Segment`, `Transcript`, and `Chunk` TypedDicts defined in `koffee/schemas/types.py`. Covers the full transcript flow from `asr.transcribe()` through `translator.translate()` into the subtitle generators. Runtime shape is unchanged; only the static contract is tightened.