### PR TITLE
Add KoffeeError base class for library-wide error handling

### DIFF
--- a/koffee/api.py
+++ b/koffee/api.py
@@ -12,6 +12,7 @@ from koffee.embed import embed_subtitles
 from koffee.exceptions import (
     IncompatibleOptionsError,
     InvalidVideoFileError,
+    MissingApiKeyError,
     MissingDependencyError,
     UnsupportedFileError,
 )
@@ -118,14 +119,14 @@ def _validate_inputs(video_file_path: Path | str, config: KoffeeConfig) -> None:
 
 
 def _validate_api_key(config: KoffeeConfig) -> None:
-    """Raises ValueError if an LLM backend is selected without an API key."""
+    """Raises MissingApiKeyError if an LLM backend is selected without an API key."""
     if config.provider not in ("whisper", "ollama") and not config.api_key:
         error_message = (
             f"An API key is required when using the {config.provider} "
             "translation backend. Provide one with --api_key or set the appropriate "
             "environment variable."
         )
-        raise ValueError(error_message)
+        raise MissingApiKeyError(error_message)
 
 
 def _validate_output_path(video_file_path: Path | str, config: KoffeeConfig) -> None:

--- a/koffee/cli.py
+++ b/koffee/cli.py
@@ -23,7 +23,7 @@ from rich.table import Table
 from koffee import asr
 from koffee.api import SUBTITLE_EXTENSIONS, SUPPORTED_EXTENSIONS, _write_output, run
 from koffee.embed import embed_subtitles
-from koffee.exceptions import InvalidVideoFileError, SubtitleEmbedError
+from koffee.exceptions import KoffeeError
 from koffee.schemas.config import (
     CONFIG_SEARCH_PATHS,
     LANGUAGE_CODES,
@@ -226,9 +226,7 @@ def cli(
             except (
                 FileExistsError,
                 FileNotFoundError,
-                InvalidVideoFileError,
-                SubtitleEmbedError,
-                ValueError,
+                KoffeeError,
                 subprocess.CalledProcessError,
                 subprocess.TimeoutExpired,
             ) as exc:

--- a/koffee/exceptions.py
+++ b/koffee/exceptions.py
@@ -1,25 +1,33 @@
 """Exceptions for koffee."""
 
 
-class IncompatibleOptionsError(Exception):
+class KoffeeError(Exception):
+    """Base class for all koffee-specific errors."""
+
+
+class IncompatibleOptionsError(KoffeeError):
     """Config options incompatible with the input file."""
 
 
-class InvalidSubtitleFormatError(Exception):
+class InvalidSubtitleFormatError(KoffeeError):
     """Subtitle format is invalid or not supported."""
 
 
-class InvalidVideoFileError(Exception):
+class InvalidVideoFileError(KoffeeError):
     """Video file is invalid or does not exist."""
 
 
-class MissingDependencyError(Exception):
+class MissingApiKeyError(KoffeeError):
+    """LLM backend selected without a required API key."""
+
+
+class MissingDependencyError(KoffeeError):
     """Required external executable not found on PATH."""
 
 
-class SubtitleEmbedError(Exception):
+class SubtitleEmbedError(KoffeeError):
     """Subtitle embedding not possible for the given file."""
 
 
-class UnsupportedFileError(Exception):
+class UnsupportedFileError(KoffeeError):
     """Input file has an unsupported extension."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -22,6 +22,7 @@ from koffee.api import (
 from koffee.exceptions import (
     IncompatibleOptionsError,
     InvalidVideoFileError,
+    MissingApiKeyError,
     MissingDependencyError,
     UnsupportedFileError,
 )
@@ -198,8 +199,8 @@ def test_write_output_overwrites_when_allowed(tmp_path) -> None:
 
 
 def test_validate_api_key_raises_without_key() -> None:
-    """Tests that an LLM backend without API key raises ValueError."""
-    with pytest.raises(ValueError, match="API key is required"):
+    """Tests that an LLM backend without API key raises MissingApiKeyError."""
+    with pytest.raises(MissingApiKeyError, match="API key is required"):
         koffee.run(
             "examples/videos/sample_korean_video.mp4",
             provider="gemini",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,6 +21,7 @@ from koffee.cli import (
     tracks,
     transcribe,
 )
+from koffee.exceptions import KoffeeError
 from koffee.schemas.config import LANGUAGE_CODES, KoffeeConfig
 
 korean_video_file_path = Path("examples/videos/sample_korean_video.mp4")
@@ -290,7 +291,7 @@ def test_batch_summary_on_success(mocker: MockerFixture) -> None:
 
 def test_batch_summary_on_partial_failure(mocker: MockerFixture) -> None:
     """Tests that batch processing logs failed files in the summary."""
-    mocker.patch("koffee.cli.run", side_effect=[None, ValueError("boom")])
+    mocker.patch("koffee.cli.run", side_effect=[None, KoffeeError("boom")])
     mocker.patch("koffee.cli.get_subtitle_tracks", return_value=[])
     mock_log = mocker.patch("koffee.cli.log")
 


### PR DESCRIPTION
## Summary
Introduces `KoffeeError(Exception)` as a root class for all koffee-specific errors and re-parents the six existing exceptions. Replaces a bare `ValueError` in `_validate_api_key` with a new `MissingApiKeyError(KoffeeError)`. Collapses the CLI's failure-handling catch tuple to one koffee entry, forward-compatible as more error types are added, and gives library callers a single `except KoffeeError` boundary.