### PR TITLE
Drop redundant _file_ suffix from path variable names

### DIFF
--- a/examples/video_translation_example.py
+++ b/examples/video_translation_example.py
@@ -3,8 +3,8 @@
 import koffee
 
 if __name__ == "__main__":
-    video_file_path = "examples/videos/sample_korean_video.mp4"
+    video_path = "examples/videos/sample_korean_video.mp4"
     output_dir = "scratch"
     output_name = "example_video"
 
-    koffee.run(video_file_path)
+    koffee.run(video_path)

--- a/features/steps/api.py
+++ b/features/steps/api.py
@@ -17,10 +17,10 @@ SUBTITLE_EXTENSIONS = {".srt", ".vtt", ".ass"}
 def step_given(context: Context, language: str) -> None:
     """Adds a path to a good video file to the context."""
     if language == "Korean":
-        context.video_file_path = Path("examples/videos/sample_korean_video.mp4")
+        context.video_path = Path("examples/videos/sample_korean_video.mp4")
         context.output_name = "sample_korean_video_test"
     elif language == "Japanese":
-        context.video_file_path = Path("examples/videos/sample_japanese_video.mp4")
+        context.video_path = Path("examples/videos/sample_japanese_video.mp4")
         context.output_name = "sample_japanese_video_test"
 
 
@@ -37,8 +37,8 @@ def step_impl(context: Context):
     output_name = getattr(context, "output_name", None)
 
     try:
-        context.output_file_path = run(
-            context.video_file_path,
+        context.output_path = run(
+            context.video_path,
             output_dir=output_dir,
             output_name=output_name,
             overwrite=True,
@@ -50,14 +50,14 @@ def step_impl(context: Context):
 @then("the user receives a subtitle file")
 def step_impl(context: Context):
     """Assert that the output subtitle file exists with a valid subtitle extension."""
-    assert context.output_file_path.exists()
-    assert context.output_file_path.suffix in SUBTITLE_EXTENSIONS
+    assert context.output_path.exists()
+    assert context.output_path.suffix in SUBTITLE_EXTENSIONS
 
 
 @given("the user corrupts the file somehow")
 def step_impl(context: Context):
     """Corrupts a video file."""
-    context.video_file_path = Path("invalid_video_file.mp4")
+    context.video_path = Path("invalid_video_file.mp4")
 
 
 @then("the user receives the error message {error_message}")

--- a/koffee/api.py
+++ b/koffee/api.py
@@ -35,7 +35,7 @@ SUPPORTED_EXTENSIONS = AUDIO_EXTENSIONS | VIDEO_EXTENSIONS
 
 
 def run(
-    video_file_path: Path | str,
+    input_path: Path | str,
     config: KoffeeConfig | None = None,
     on_asr_progress: Callable[[float], None] | None = None,
     on_translate_progress: Callable[[float], None] | None = None,
@@ -45,36 +45,34 @@ def run(
     log.info("Translating file...")
 
     config = _apply_config_overrides(config, kwargs)
-    _validate_inputs(video_file_path, config)
+    _validate_inputs(input_path, config)
 
-    if Path(video_file_path).suffix.lower() in SUBTITLE_EXTENSIONS:
-        return _translate_subtitle_file(video_file_path, config, on_translate_progress)
+    if Path(input_path).suffix.lower() in SUBTITLE_EXTENSIONS:
+        return _translate_subtitle_file(input_path, config, on_translate_progress)
 
     if config.use_embedded_subtitles:
-        return _translate_embedded_subtitles(
-            video_file_path, config, on_translate_progress
-        )
+        return _translate_embedded_subtitles(input_path, config, on_translate_progress)
 
-    transcript = _transcribe(video_file_path, config, on_asr_progress)
-    subtitle_file_path = _translate(transcript, config, on_translate_progress)
-    output_path = _route_output(video_file_path, subtitle_file_path, config)
+    transcript = _transcribe(input_path, config, on_asr_progress)
+    subtitle_path = _translate(transcript, config, on_translate_progress)
+    output_path = _route_output(input_path, subtitle_path, config)
 
     return output_path
 
 
-def _validate_file(video_file_path: Path | str) -> None:
+def _validate_file(input_path: Path | str) -> None:
     """Raises InvalidVideoFileError if the file does not exist or is not a file."""
-    if not Path(video_file_path).exists() or not Path(video_file_path).is_file():
+    if not Path(input_path).exists() or not Path(input_path).is_file():
         error_message = "Input file is not valid or does not exist."
         log.error(error_message)
         raise InvalidVideoFileError(error_message)
 
 
-def _validate_inputs(video_file_path: Path | str, config: KoffeeConfig) -> None:
+def _validate_inputs(input_path: Path | str, config: KoffeeConfig) -> None:
     """Runs pre-flight checks on the input file, dependencies, and config options."""
-    _validate_file(video_file_path)
+    _validate_file(input_path)
 
-    suffix = Path(video_file_path).suffix.lower()
+    suffix = Path(input_path).suffix.lower()
     allowed = SUPPORTED_EXTENSIONS | SUBTITLE_EXTENSIONS
     if suffix not in allowed:
         error_message = (
@@ -110,12 +108,12 @@ def _validate_inputs(video_file_path: Path | str, config: KoffeeConfig) -> None:
                 "--use-embedded-subtitles."
             )
             raise MissingDependencyError(error_message)
-        if not get_subtitle_tracks(video_file_path):
-            error_message = f"No embedded subtitle tracks found in {video_file_path}."
+        if not get_subtitle_tracks(input_path):
+            error_message = f"No embedded subtitle tracks found in {input_path}."
             raise IncompatibleOptionsError(error_message)
 
     _validate_api_key(config)
-    _validate_output_path(video_file_path, config)
+    _validate_output_path(input_path, config)
 
 
 def _validate_api_key(config: KoffeeConfig) -> None:
@@ -129,16 +127,16 @@ def _validate_api_key(config: KoffeeConfig) -> None:
         raise MissingApiKeyError(error_message)
 
 
-def _validate_output_path(video_file_path: Path | str, config: KoffeeConfig) -> None:
+def _validate_output_path(input_path: Path | str, config: KoffeeConfig) -> None:
     """Ensures the resolved output path is writable and not already occupied."""
-    input_suffix = Path(video_file_path).suffix.lower()
+    input_suffix = Path(input_path).suffix.lower()
     is_video = input_suffix in VIDEO_EXTENSIONS
     has_embed = (
         is_video and not config.use_embedded_subtitles and config.embed != "none"
     )
 
     base_path = _get_output_path(
-        video_file_path, config.output_dir, config.output_name, date_suffix=has_embed
+        input_path, config.output_dir, config.output_name, date_suffix=has_embed
     )
     output_path = (
         base_path if has_embed else base_path.with_suffix(f".{config.subtitle_format}")
@@ -158,13 +156,13 @@ def _apply_config_overrides(config: KoffeeConfig | None, kwargs: dict) -> Koffee
 
 
 def _transcribe(
-    video_file_path: Path | str,
+    input_path: Path | str,
     config: KoffeeConfig,
     on_progress: Callable[[float], None] | None,
 ) -> Transcript:
     """Transcribes audio from the file, returning the raw transcript."""
     transcript = transcribe(
-        str(video_file_path),
+        str(input_path),
         config.compute_type,
         config.device,
         config.whisper_model,
@@ -183,9 +181,9 @@ def _translate(
 ) -> Path:
     """Translates transcript segments and writes the subtitle file."""
     segments = _get_segments(transcript, config, on_progress=on_progress)
-    subtitle_file_path = generate_subtitles(config.subtitle_format, segments)
+    subtitle_path = generate_subtitles(config.subtitle_format, segments)
 
-    return subtitle_file_path
+    return subtitle_path
 
 
 def _check_output_collision(output_path: Path, overwrite: bool) -> None:
@@ -198,51 +196,49 @@ def _check_output_collision(output_path: Path, overwrite: bool) -> None:
 
 
 def _route_output(
-    video_file_path: Path | str,
-    subtitle_file_path: Path,
+    input_path: Path | str,
+    subtitle_path: Path,
     config: KoffeeConfig,
 ) -> Path:
     """Routes to subtitle output or video embed based on file type and config."""
-    is_audio = Path(video_file_path).suffix.lower() in AUDIO_EXTENSIONS
+    is_audio = Path(input_path).suffix.lower() in AUDIO_EXTENSIONS
     has_embed = not is_audio and config.embed != "none"
 
     output_path = _get_output_path(
-        video_file_path, config.output_dir, config.output_name, date_suffix=has_embed
+        input_path, config.output_dir, config.output_name, date_suffix=has_embed
     )
 
     if has_embed:
         _check_output_collision(output_path, config.overwrite)
-        output_file_path = _finalize_video_output(
-            subtitle_file_path,
-            video_file_path,
+        result_path = _finalize_video_output(
+            subtitle_path,
+            input_path,
             output_path,
             config.embed,
             config.target_language,
         )
     else:
-        output_file_path = _write_output(
-            subtitle_file_path,
-            video_file_path,
+        result_path = _write_output(
+            subtitle_path,
+            input_path,
             config.subtitle_format,
             config.output_dir,
             config.output_name,
             config.overwrite,
         )
 
-    return output_file_path
+    return result_path
 
 
 def _translate_embedded_subtitles(
-    video_file_path: Path | str,
+    input_path: Path | str,
     config: KoffeeConfig,
     on_progress: Callable[[float], None] | None,
 ) -> Path:
     """Extracts embedded subtitles from a video and translates them."""
     log.info("Extracting embedded subtitles from video.")
 
-    extracted_path = extract_subtitle_track(
-        video_file_path, config.subtitle_track_index
-    )
+    extracted_path = extract_subtitle_track(input_path, config.subtitle_track_index)
     try:
         result = _translate_subtitle_file(extracted_path, config, on_progress)
     finally:
@@ -284,7 +280,7 @@ def _translate_subtitle_file(
 
 
 def _get_output_path(
-    video_file_path: Path | str,
+    input_path: Path | str,
     output_dir: Path | None,
     output_name: str | None,
     date_suffix: bool = False,
@@ -292,7 +288,7 @@ def _get_output_path(
     """Gets the output path for the translated output file."""
     log.debug(f"output_name: {output_name!r}")
 
-    file_path = Path(video_file_path)
+    file_path = Path(input_path)
     file_dir = output_dir if output_dir is not None else file_path.parent
     file_dir.mkdir(parents=True, exist_ok=True)
 
@@ -335,21 +331,21 @@ def _get_segments(
 
 
 def _finalize_video_output(
-    subtitle_file_path: Path,
-    video_file_path: Path,
+    subtitle_path: Path,
+    input_path: Path,
     output_path: Path,
     embed_mode: str = "soft",
     language: str = "en",
 ) -> Path:
     """Embeds subtitles into the video and deletes the subtitle file after."""
     output_video = embed_subtitles(
-        subtitle_file_path,
-        video_file_path,
+        subtitle_path,
+        input_path,
         output_path,
         mode=embed_mode,
         language=language,
     )
-    subtitle_file_path.unlink()
+    subtitle_path.unlink()
     log.info("Finished processing video!")
 
     return output_video

--- a/koffee/cli.py
+++ b/koffee/cli.py
@@ -360,7 +360,7 @@ def _translate_with_progress(
     if skip_asr:
         translate_task = progress.add_task("Translating", total=100)
         run(
-            video_file_path=video_path,
+            input_path=video_path,
             config=config,
             on_translate_progress=_make_progress_callback(progress, translate_task),
         )
@@ -385,7 +385,7 @@ def _translate_with_progress(
                     progress.start_task(translate_task)
 
         run(
-            video_file_path=video_path,
+            input_path=video_path,
             config=config,
             on_asr_progress=on_asr_progress,
             on_translate_progress=translate_callback,
@@ -581,10 +581,10 @@ def transcribe(
 
     segments = transcript["segments"]
     out_dir = output_dir if output_dir is not None else file_path.parent
-    subtitle_file_path = generate_subtitles(subtitle_format, segments, out_dir)
+    subtitle_path = generate_subtitles(subtitle_format, segments, out_dir)
 
     target_path = _write_output(
-        subtitle_file_path,
+        subtitle_path,
         file_path,
         subtitle_format,
         output_dir,
@@ -621,10 +621,10 @@ def convert(
     """
     segments = parse_subtitle_file(file_path)
     out_dir = output_dir if output_dir is not None else file_path.parent
-    subtitle_file_path = generate_subtitles(subtitle_format, segments, out_dir)
+    subtitle_path = generate_subtitles(subtitle_format, segments, out_dir)
 
     target_path = _write_output(
-        subtitle_file_path,
+        subtitle_path,
         file_path,
         subtitle_format,
         output_dir,

--- a/koffee/embed.py
+++ b/koffee/embed.py
@@ -12,53 +12,51 @@ log = logging.getLogger(__name__)
 MKV_EXTENSIONS = {".mkv", ".webm"}
 
 
-def _get_subtitle_codec(output_file_path: Path | str) -> str:
+def _get_subtitle_codec(output_path: Path | str) -> str:
     """Returns the appropriate subtitle codec for the output container."""
-    if Path(output_file_path).suffix.lower() in MKV_EXTENSIONS:
+    if Path(output_path).suffix.lower() in MKV_EXTENSIONS:
         return "srt"
     return "mov_text"
 
 
 def embed_subtitles(
-    subtitle_file_path: Path | str,
-    video_file_path: Path | str,
-    output_file_path: Path | str,
+    subtitle_path: Path | str,
+    video_path: Path | str,
+    output_path: Path | str,
     mode: str = "soft",
     language: str = "eng",
 ) -> Path | str:
     """Embeds subtitles into a video file.
 
     Args:
-        subtitle_file_path: Path to the subtitle file.
-        video_file_path: Path to the source video file.
-        output_file_path: Path for the output video file.
+        subtitle_path: Path to the subtitle file.
+        video_path: Path to the source video file.
+        output_path: Path for the output video file.
         mode: "soft" for muxed subtitle track, "hard" for burned-in subtitles.
         language: ISO 639-2 language code for the subtitle metadata.
     """
     if mode == "hard":
-        return _burn_in_subtitles(subtitle_file_path, video_file_path, output_file_path)
-    return _mux_subtitles(
-        subtitle_file_path, video_file_path, output_file_path, language
-    )
+        return _burn_in_subtitles(subtitle_path, video_path, output_path)
+    return _mux_subtitles(subtitle_path, video_path, output_path, language)
 
 
 def _mux_subtitles(
-    subtitle_file_path: Path | str,
-    video_file_path: Path | str,
-    output_file_path: Path | str,
+    subtitle_path: Path | str,
+    video_path: Path | str,
+    output_path: Path | str,
     language: str = "eng",
 ) -> Path | str:
     """Muxes subtitles as a soft track (original behavior)."""
     log.info("Embedding subtitles (soft).")
 
-    subtitle_codec = _get_subtitle_codec(output_file_path)
+    subtitle_codec = _get_subtitle_codec(output_path)
 
     cmd = [
         "ffmpeg",
         "-i",
-        str(video_file_path),
+        str(video_path),
         "-i",
-        str(subtitle_file_path),
+        str(subtitle_path),
         "-c",
         "copy",
         "-c:s",
@@ -66,7 +64,7 @@ def _mux_subtitles(
         "-metadata:s:s:0",
         f"language={language}",
         "-y",
-        str(output_file_path),
+        str(output_path),
     ]
 
     try:
@@ -80,37 +78,37 @@ def _mux_subtitles(
     except subprocess.CalledProcessError as error:
         raise SubtitleEmbedError(error.stderr) from error
 
-    return output_file_path
+    return output_path
 
 
-def _escape_subtitle_filter_path(subtitle_file_path: Path | str) -> str:
+def _escape_subtitle_filter_path(subtitle_path: Path | str) -> str:
     """Escapes a path for use in the ffmpeg `subtitles=` filter argument."""
-    path = str(subtitle_file_path).replace("\\", "/")
+    path = str(subtitle_path).replace("\\", "/")
     for char in (":", "'", "[", "]", ",", ";"):
         path = path.replace(char, f"\\{char}")
     return path
 
 
 def _burn_in_subtitles(
-    subtitle_file_path: Path | str,
-    video_file_path: Path | str,
-    output_file_path: Path | str,
+    subtitle_path: Path | str,
+    video_path: Path | str,
+    output_path: Path | str,
 ) -> Path | str:
     """Burns subtitles into the video frames (hard subtitles)."""
     log.info("Burning in subtitles (hard).")
 
-    escaped_path = _escape_subtitle_filter_path(subtitle_file_path)
+    escaped_path = _escape_subtitle_filter_path(subtitle_path)
 
     cmd = [
         "ffmpeg",
         "-i",
-        str(video_file_path),
+        str(video_path),
         "-vf",
         f"subtitles={escaped_path}",
         "-c:a",
         "copy",
         "-y",
-        str(output_file_path),
+        str(output_path),
     ]
 
     try:
@@ -124,4 +122,4 @@ def _burn_in_subtitles(
     except subprocess.CalledProcessError as error:
         raise SubtitleEmbedError(error.stderr) from error
 
-    return output_file_path
+    return output_path

--- a/koffee/subtitle.py
+++ b/koffee/subtitle.py
@@ -21,13 +21,13 @@ def generate_subtitles(
         output_dir = Path.cwd()
 
     if subtitle_format == "srt":
-        subtitle_file_path = convert_segments_to_srt(segments, output_dir)
+        subtitle_path = convert_segments_to_srt(segments, output_dir)
     elif subtitle_format == "vtt":
-        subtitle_file_path = convert_segments_to_vtt(segments, output_dir)
+        subtitle_path = convert_segments_to_vtt(segments, output_dir)
     elif subtitle_format == "ass":
-        subtitle_file_path = convert_segments_to_ass(segments, output_dir)
+        subtitle_path = convert_segments_to_ass(segments, output_dir)
     else:
         error_message = f"Invalid or unsupported subtitle format: {subtitle_format}"
         raise InvalidSubtitleFormatError(error_message)
 
-    return subtitle_file_path
+    return subtitle_path

--- a/koffee/utils/ass_converter.py
+++ b/koffee/utils/ass_converter.py
@@ -45,10 +45,10 @@ def convert_segments_to_ass(segments: list[Segment], output_dir: Path) -> Path:
     """Converts segments to ASS format."""
     log.debug("Converting segments to ASS format.")
 
-    output_file_path = output_dir / f"subtitles_{uuid.uuid4().hex[:8]}.ass"
-    log.debug(f"output_file_path: {output_file_path!r}")
+    output_path = output_dir / f"subtitles_{uuid.uuid4().hex[:8]}.ass"
+    log.debug(f"output_path: {output_path!r}")
 
-    with Path.open(output_file_path, "w", encoding="utf-8") as file:
+    with Path.open(output_path, "w", encoding="utf-8") as file:
         file.write(ASS_HEADER)
 
         for subtitle in segments:
@@ -57,4 +57,4 @@ def convert_segments_to_ass(segments: list[Segment], output_dir: Path) -> Path:
             text = subtitle["text"].strip().replace("\n", "\\N")
             file.write(f"Dialogue: 0,{start},{end},Default,,0,0,0,,{text}\n")
 
-    return output_file_path
+    return output_path

--- a/koffee/utils/get_video_duration.py
+++ b/koffee/utils/get_video_duration.py
@@ -7,7 +7,7 @@ from pathlib import Path
 log = logging.getLogger(__name__)
 
 
-def get_video_duration(video_file_path: Path | str) -> float:
+def get_video_duration(video_path: Path | str) -> float:
     """Gets the duration in seconds using ffprobe."""
     try:
         result = subprocess.run(
@@ -19,7 +19,7 @@ def get_video_duration(video_file_path: Path | str) -> float:
                 "format=duration",
                 "-of",
                 "default=noprint_wrappers=1:nokey=1",
-                str(video_file_path),
+                str(video_path),
             ],
             capture_output=True,
             text=True,

--- a/koffee/utils/srt_converter.py
+++ b/koffee/utils/srt_converter.py
@@ -14,8 +14,8 @@ def convert_segments_to_srt(segments: list[Segment], output_dir: Path) -> Path:
     """Converts segments to SRT format."""
     log.debug("Converting segments to SRT format.")
 
-    output_file_path = output_dir / f"subtitles_{uuid.uuid4().hex[:8]}.srt"
-    log.debug(f"output_file_path: {output_file_path!r}")
+    output_path = output_dir / f"subtitles_{uuid.uuid4().hex[:8]}.srt"
+    log.debug(f"output_path: {output_path!r}")
 
     blocks = []
     for idx, subtitle in enumerate(segments, 1):
@@ -24,7 +24,7 @@ def convert_segments_to_srt(segments: list[Segment], output_dir: Path) -> Path:
         text = subtitle["text"].strip()
         blocks.append(f"{idx}\n{start} --> {end}\n{text}")
 
-    with Path.open(output_file_path, "w", encoding="utf-8") as file:
+    with Path.open(output_path, "w", encoding="utf-8") as file:
         file.write("\n\n".join(blocks) + "\n")
 
-    return output_file_path
+    return output_path

--- a/koffee/utils/subtitle_extractor.py
+++ b/koffee/utils/subtitle_extractor.py
@@ -8,7 +8,7 @@ from pathlib import Path
 log = logging.getLogger(__name__)
 
 
-def get_subtitle_tracks(video_file_path: Path | str) -> list[dict]:
+def get_subtitle_tracks(video_path: Path | str) -> list[dict]:
     """Returns a list of subtitle track metadata from a video file."""
     try:
         result = subprocess.run(
@@ -22,7 +22,7 @@ def get_subtitle_tracks(video_file_path: Path | str) -> list[dict]:
                 "stream=index:stream_tags=language,title",
                 "-of",
                 "json",
-                str(video_file_path),
+                str(video_path),
             ],
             capture_output=True,
             text=True,
@@ -40,16 +40,16 @@ def get_subtitle_tracks(video_file_path: Path | str) -> list[dict]:
     return data.get("streams", [])
 
 
-def extract_subtitle_track(video_file_path: Path | str, track_index: int = 0) -> Path:
+def extract_subtitle_track(video_path: Path | str, track_index: int = 0) -> Path:
     """Extracts a subtitle track from a video file to a temporary SRT file."""
-    output_path = Path(video_file_path).parent / f".koffee_extracted_{track_index}.srt"
+    output_path = Path(video_path).parent / f".koffee_extracted_{track_index}.srt"
 
     try:
         subprocess.run(
             [
                 "ffmpeg",
                 "-i",
-                str(video_file_path),
+                str(video_path),
                 "-map",
                 f"0:s:{track_index}",
                 "-f",

--- a/koffee/utils/vtt_converter.py
+++ b/koffee/utils/vtt_converter.py
@@ -14,8 +14,8 @@ def convert_segments_to_vtt(segments: list[Segment], output_dir: Path) -> Path:
     """Converts segments to VTT format."""
     log.debug("Converting segments to VTT format.")
 
-    output_file_path = output_dir / f"subtitles_{uuid.uuid4().hex[:8]}.vtt"
-    log.debug(f"output_file_path: {output_file_path!r}")
+    output_path = output_dir / f"subtitles_{uuid.uuid4().hex[:8]}.vtt"
+    log.debug(f"output_path: {output_path!r}")
 
     blocks = []
     for subtitle in segments:
@@ -24,7 +24,7 @@ def convert_segments_to_vtt(segments: list[Segment], output_dir: Path) -> Path:
         text = subtitle["text"].strip()
         blocks.append(f"{start} --> {end}\n{text}")
 
-    with Path.open(output_file_path, "w", encoding="utf-8") as file:
+    with Path.open(output_path, "w", encoding="utf-8") as file:
         file.write("WEBVTT\n\n" + "\n\n".join(blocks) + "\n")
 
-    return output_file_path
+    return output_path

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -39,12 +39,12 @@ def api_module():
 @pytest.mark.integration
 def test_api() -> None:
     """Tests if the API call successfully outputs a subtitle file."""
-    video_file_path = Path("examples/videos/sample_korean_video.mp4")
+    video_path = Path("examples/videos/sample_korean_video.mp4")
     output_directory_path = Path("scratch")
     output_file_name = "python_output_video_file"
 
     output_file = koffee.run(
-        video_file_path=video_file_path,
+        input_path=video_path,
         output_dir=output_directory_path,
         output_name=output_file_name,
         compute_type="int8",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,7 +24,7 @@ from koffee.cli import (
 from koffee.exceptions import KoffeeError
 from koffee.schemas.config import LANGUAGE_CODES, KoffeeConfig
 
-korean_video_file_path = Path("examples/videos/sample_korean_video.mp4")
+korean_video_path = Path("examples/videos/sample_korean_video.mp4")
 
 output_directory_path = Path("scratch")
 output_file_name = "cli_output_video_file"
@@ -35,7 +35,7 @@ def test_cli(mocker: MockerFixture) -> None:
     mock_translate = mocker.patch("koffee.cli.run")
 
     cli(
-        korean_video_file_path,
+        korean_video_path,
         compute_type="int8",
         output_dir=output_directory_path,
         output_name=output_file_name,
@@ -64,7 +64,7 @@ def test_embed_soft(mocker: MockerFixture) -> None:
     mock_translate = mocker.patch("koffee.cli.run")
 
     cli(
-        korean_video_file_path,
+        korean_video_path,
         compute_type="int8",
         output_dir=output_directory_path,
         output_name=output_file_name,
@@ -82,7 +82,7 @@ def test_embed_defaults_to_none(mocker: MockerFixture) -> None:
     mock_translate = mocker.patch("koffee.cli.run")
 
     cli(
-        korean_video_file_path,
+        korean_video_path,
         compute_type="int8",
         output_dir=output_directory_path,
         output_name=output_file_name,
@@ -101,7 +101,7 @@ def test_verbose(mocker: MockerFixture) -> None:
     logger_instance = mock_logger.return_value
 
     cli(
-        korean_video_file_path,
+        korean_video_path,
         compute_type="int8",
         output_dir=output_directory_path,
         output_name=output_file_name,
@@ -151,7 +151,7 @@ def test_dry_run(mocker: MockerFixture) -> None:
     mocker.patch("koffee.cli.get_subtitle_tracks", return_value=[])
 
     cli(
-        korean_video_file_path,
+        korean_video_path,
         output_dir=output_directory_path,
         dry_run=True,
     )
@@ -177,7 +177,7 @@ def test_dry_run_with_embed(mocker: MockerFixture) -> None:
     mocker.patch("koffee.cli.get_subtitle_tracks", return_value=[])
 
     cli(
-        korean_video_file_path,
+        korean_video_path,
         output_dir=output_directory_path,
         dry_run=True,
         embed="soft",
@@ -204,7 +204,7 @@ def test_handle_embedded_subtitles_no_tracks(
     mocker.patch("koffee.cli.get_subtitle_tracks", return_value=[])
     config = KoffeeConfig()
 
-    result = _handle_embedded_subtitles(korean_video_file_path, config)
+    result = _handle_embedded_subtitles(korean_video_path, config)
 
     assert result.use_embedded_subtitles is False
 
@@ -218,7 +218,7 @@ def test_handle_embedded_subtitles_user_accepts(
     mocker.patch("builtins.input", return_value="y")
     config = KoffeeConfig()
 
-    result = _handle_embedded_subtitles(korean_video_file_path, config)
+    result = _handle_embedded_subtitles(korean_video_path, config)
 
     assert result.use_embedded_subtitles is True
     assert result.source_language == "ko"
@@ -235,7 +235,7 @@ def test_handle_embedded_subtitles_user_declines(
     mocker.patch("builtins.input", return_value="n")
     config = KoffeeConfig()
 
-    result = _handle_embedded_subtitles(korean_video_file_path, config)
+    result = _handle_embedded_subtitles(korean_video_path, config)
 
     assert result.use_embedded_subtitles is False
 
@@ -262,8 +262,8 @@ def test_batch_progress_logging(mocker: MockerFixture) -> None:
     mock_log = mocker.patch("koffee.cli.log")
 
     cli(
-        korean_video_file_path,
-        korean_video_file_path,
+        korean_video_path,
+        korean_video_path,
         output_dir=output_directory_path,
     )
 
@@ -280,8 +280,8 @@ def test_batch_summary_on_success(mocker: MockerFixture) -> None:
     mock_log = mocker.patch("koffee.cli.log")
 
     cli(
-        korean_video_file_path,
-        korean_video_file_path,
+        korean_video_path,
+        korean_video_path,
         output_dir=output_directory_path,
     )
 
@@ -296,8 +296,8 @@ def test_batch_summary_on_partial_failure(mocker: MockerFixture) -> None:
     mock_log = mocker.patch("koffee.cli.log")
 
     cli(
-        korean_video_file_path,
-        korean_video_file_path,
+        korean_video_path,
+        korean_video_path,
         output_dir=output_directory_path,
     )
 
@@ -314,7 +314,7 @@ def test_prompt_flag(mocker: MockerFixture) -> None:
     mocker.patch("koffee.cli.get_subtitle_tracks", return_value=[])
 
     cli(
-        korean_video_file_path,
+        korean_video_path,
         output_dir=output_directory_path,
         prompt="You are a medical translator.",
     )
@@ -333,7 +333,7 @@ def test_config_flag_loads_file(mocker: MockerFixture, tmp_path) -> None:
     mocker.patch("koffee.cli.get_subtitle_tracks", return_value=[])
 
     cli(
-        korean_video_file_path,
+        korean_video_path,
         config=config_file,
         output_dir=output_directory_path,
     )
@@ -421,14 +421,14 @@ def test_tracks_command(mocker: MockerFixture) -> None:
         ],
     )
 
-    tracks(korean_video_file_path)
+    tracks(korean_video_path)
 
 
 def test_tracks_command_no_tracks(mocker: MockerFixture) -> None:
     """Tests that tracks command handles no subtitle tracks."""
     mocker.patch("koffee.cli.get_subtitle_tracks", return_value=[])
 
-    tracks(korean_video_file_path)
+    tracks(korean_video_path)
 
 
 def test_find_config_path_returns_none(monkeypatch) -> None:

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -15,39 +15,35 @@ from koffee.exceptions import SubtitleEmbedError
 
 
 @pytest.fixture
-def video_file_path() -> Path:
+def video_path() -> Path:
     """Pytest fixture for the video file path."""
     return Path("examples/videos/sample_korean_video.mp4")
 
 
 @pytest.fixture
-def subtitle_file_path() -> Path:
+def subtitle_path() -> Path:
     """Pytest fixture for the subtitles."""
     return Path("examples/subtitles/sample_srt_file.srt")
 
 
 @pytest.fixture
-def output_file_path() -> Path:
+def output_path() -> Path:
     """Pytest fixture for the output file path."""
     return Path("scratch/output_with_subtitles.mp4")
 
 
-def test_overlay(
-    video_file_path: Path, subtitle_file_path: Path, output_file_path: Path
-) -> None:
+def test_overlay(video_path: Path, subtitle_path: Path, output_path: Path) -> None:
     """Tests that the subtitle has been overlayed onto the video."""
-    embed_subtitles(subtitle_file_path, video_file_path, output_file_path)
+    embed_subtitles(subtitle_path, video_path, output_path)
 
-    assert output_file_path.exists()
+    assert output_path.exists()
 
 
-def test_hard_overlay(
-    video_file_path: Path, subtitle_file_path: Path, output_file_path: Path
-) -> None:
+def test_hard_overlay(video_path: Path, subtitle_path: Path, output_path: Path) -> None:
     """Tests that hard burn-in produces an output file."""
-    embed_subtitles(subtitle_file_path, video_file_path, output_file_path, mode="hard")
+    embed_subtitles(subtitle_path, video_path, output_path, mode="hard")
 
-    assert output_file_path.exists()
+    assert output_path.exists()
 
 
 def test_mkv_codec() -> None:
@@ -58,9 +54,9 @@ def test_mkv_codec() -> None:
 
 
 def test_exception_handling(
-    subtitle_file_path: Path,
-    video_file_path: Path,
-    output_file_path: Path,
+    subtitle_path: Path,
+    video_path: Path,
+    output_path: Path,
     mocker: MockerFixture,
 ) -> None:
     """Tests that exception is caught and an error is raised."""
@@ -72,16 +68,16 @@ def test_exception_handling(
     )
 
     with pytest.raises(SubtitleEmbedError) as exc_info:
-        embed_subtitles(subtitle_file_path, video_file_path, output_file_path)
+        embed_subtitles(subtitle_path, video_path, output_path)
 
     assert isinstance(exc_info.value.__cause__, subprocess.CalledProcessError)
     assert "FFmpegError" in str(exc_info.value)
 
 
 def test_missing_ffmpeg_raises(
-    subtitle_file_path: Path,
-    video_file_path: Path,
-    output_file_path: Path,
+    subtitle_path: Path,
+    video_path: Path,
+    output_path: Path,
     mocker: MockerFixture,
 ) -> None:
     """Tests that missing ffmpeg raises FileNotFoundError."""
@@ -91,7 +87,7 @@ def test_missing_ffmpeg_raises(
     )
 
     with pytest.raises(FileNotFoundError):
-        embed_subtitles(subtitle_file_path, video_file_path, output_file_path)
+        embed_subtitles(subtitle_path, video_path, output_path)
 
 
 def test_escape_subtitle_filter_path_windows_drive() -> None:
@@ -109,16 +105,14 @@ def test_escape_subtitle_filter_path_metacharacters() -> None:
 
 
 def test_burn_in_subtitles_uses_escaped_path(
-    video_file_path: Path,
-    output_file_path: Path,
+    video_path: Path,
+    output_path: Path,
     mocker: MockerFixture,
 ) -> None:
     """Tests that `_burn_in_subtitles` passes an escaped path to ffmpeg."""
     mock_run = mocker.patch("subprocess.run")
 
-    embed_subtitles(
-        "C:\\subs\\track.srt", video_file_path, output_file_path, mode="hard"
-    )
+    embed_subtitles("C:\\subs\\track.srt", video_path, output_path, mode="hard")
 
     cmd = mock_run.call_args[0][0]
     vf_index = cmd.index("-vf")
@@ -126,9 +120,9 @@ def test_burn_in_subtitles_uses_escaped_path(
 
 
 def test_timeout_raises(
-    subtitle_file_path: Path,
-    video_file_path: Path,
-    output_file_path: Path,
+    subtitle_path: Path,
+    video_path: Path,
+    output_path: Path,
     mocker: MockerFixture,
 ) -> None:
     """Tests that a timed-out ffmpeg raises TimeoutExpired."""
@@ -138,4 +132,4 @@ def test_timeout_raises(
     )
 
     with pytest.raises(subprocess.TimeoutExpired):
-        embed_subtitles(subtitle_file_path, video_file_path, output_file_path)
+        embed_subtitles(subtitle_path, video_path, output_path)

--- a/tests/test_subtitle.py
+++ b/tests/test_subtitle.py
@@ -53,11 +53,11 @@ def test_subtitle_generator(
         },
     ]
 
-    subtitle_file_path = generate_subtitles(subtitle_format, text, output_dir)
+    subtitle_path = generate_subtitles(subtitle_format, text, output_dir)
 
-    assert subtitle_file_path.exists()
+    assert subtitle_path.exists()
 
-    with Path.open(subtitle_file_path) as f:
+    with Path.open(subtitle_path) as f:
         actual = f.read()
 
     if subtitle_format == "srt":
@@ -99,7 +99,7 @@ On the other side, a virgin approached and opened a window in front of the Shimm
         assert "Dialogue: 0," in actual
         assert "When we got out of the long tunnel of the border" in actual
         assert "The bottom of the night has been changed." in actual
-        subtitle_file_path.unlink()
+        subtitle_path.unlink()
         return
     else:
         error_message = f"Invalid or unsupported subtitle format: {subtitle_format}"
@@ -107,7 +107,7 @@ On the other side, a virgin approached and opened a window in front of the Shimm
 
     assert actual == expected
 
-    subtitle_file_path.unlink()
+    subtitle_path.unlink()
 
 
 @pytest.mark.parametrize("subtitle_format", ["csv", "pdf", "txt"])


### PR DESCRIPTION
## Summary
Standardizes path-typed identifiers on `_path` (dropping the redundant `_file_` middle) to match the ~80% existing convention and the Python stdlib (`pathlib.Path`, `os.path.join`, etc.). Renames the public `run(video_file_path=...)` param to `input_path` since it accepts audio and subtitle inputs too — this is a breaking change for library callers passing that kwarg. Video-specific helpers (`embed_subtitles`, `get_video_duration`, `get_subtitle_tracks`) use `video_path`.