### PR TITLE
Split cli.py into a cli/ package

### DIFF
--- a/koffee/cli/__init__.py
+++ b/koffee/cli/__init__.py
@@ -1,0 +1,39 @@
+"""The koffee CLI."""
+
+from koffee.cli.app import app
+from koffee.cli.commands import (
+    _find_config_path,
+    _print_dry_run,
+    _resolve_paths,
+    _translate_with_progress,
+    cli,
+    convert,
+    embed,
+    info,
+    languages,
+    main,
+    tracks,
+    transcribe,
+)
+from koffee.cli.embedded import (
+    _handle_embedded_subtitles,
+    _select_subtitle_track,
+)
+
+__all__ = [
+    "_find_config_path",
+    "_handle_embedded_subtitles",
+    "_print_dry_run",
+    "_resolve_paths",
+    "_select_subtitle_track",
+    "_translate_with_progress",
+    "app",
+    "cli",
+    "convert",
+    "embed",
+    "info",
+    "languages",
+    "main",
+    "tracks",
+    "transcribe",
+]

--- a/koffee/cli/__main__.py
+++ b/koffee/cli/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point for `python -m koffee.cli`."""
+
+from koffee.cli.commands import main
+
+if __name__ == "__main__":
+    main()

--- a/koffee/cli/app.py
+++ b/koffee/cli/app.py
@@ -1,0 +1,42 @@
+"""Cyclopts App and shared CLI setup."""
+
+import logging
+import tomllib
+
+from cyclopts import App, Group, Parameter
+from pydantic import ValidationError
+from rich.logging import RichHandler
+
+from koffee.schemas.config import KoffeeConfig, load_config_file
+
+logging.basicConfig(
+    level=logging.INFO, format="%(message)s", datefmt="[%X]", handlers=[RichHandler()]
+)
+
+log = logging.getLogger(__name__)
+
+app = App(
+    default_parameter=Parameter(negative=""),
+    group_arguments=Group("Arguments", sort_key=0),
+    group_commands=Group("Commands", sort_key=1),
+    group_parameters=Group("Parameters", sort_key=2),
+    name="koffee",
+    version_flags=["--version", "-V"],
+)
+
+options_group = Group("Options", sort_key=3)
+
+app["--help"].group = options_group
+app["--version"].group = options_group
+
+
+def _load_cli_defaults() -> KoffeeConfig:
+    """Loads CLI defaults from the config file, falling back on invalid input."""
+    try:
+        return KoffeeConfig(**load_config_file())
+    except (ValidationError, tomllib.TOMLDecodeError) as exc:
+        log.warning(f"Ignoring invalid config file for CLI defaults: {exc}")
+        return KoffeeConfig()
+
+
+defaults = _load_cli_defaults()

--- a/koffee/cli/commands.py
+++ b/koffee/cli/commands.py
@@ -1,27 +1,21 @@
-"""The koffee CLI."""
+"""CLI command implementations."""
 
 import logging
 import shutil
 import subprocess
-import tomllib
 from pathlib import Path
 from typing import Annotated
 
-from cyclopts import App, Group, Parameter, validators
-from pydantic import ValidationError
+from cyclopts import Parameter, validators
 from rich.console import Console
-from rich.logging import RichHandler
-from rich.progress import (
-    BarColumn,
-    Progress,
-    SpinnerColumn,
-    TextColumn,
-    TimeElapsedColumn,
-)
+from rich.progress import Progress
 from rich.table import Table
 
 from koffee import asr
 from koffee.api import SUBTITLE_EXTENSIONS, SUPPORTED_EXTENSIONS, _write_output, run
+from koffee.cli.app import app, defaults, log, options_group
+from koffee.cli.embedded import _handle_embedded_subtitles
+from koffee.cli.progress import _create_progress_bar, _make_progress_callback
 from koffee.embed import embed_subtitles
 from koffee.exceptions import KoffeeError
 from koffee.schemas.config import (
@@ -33,58 +27,6 @@ from koffee.schemas.config import (
 )
 from koffee.subtitle import generate_subtitles
 from koffee.utils import get_subtitle_tracks, parse_subtitle_file
-
-logging.basicConfig(
-    level=logging.INFO, format="%(message)s", datefmt="[%X]", handlers=[RichHandler()]
-)
-
-log = logging.getLogger(__name__)
-
-app = App(
-    default_parameter=Parameter(negative=""),
-    group_arguments=Group("Arguments", sort_key=0),
-    group_commands=Group("Commands", sort_key=1),
-    group_parameters=Group("Parameters", sort_key=2),
-    name="koffee",
-    version_flags=["--version", "-V"],
-)
-
-options_group = Group("Options", sort_key=3)
-
-app["--help"].group = options_group
-app["--version"].group = options_group
-
-
-def _load_cli_defaults() -> KoffeeConfig:
-    """Loads CLI defaults from the config file, falling back on invalid input."""
-    try:
-        return KoffeeConfig(**load_config_file())
-    except (ValidationError, tomllib.TOMLDecodeError) as exc:
-        log.warning(f"Ignoring invalid config file for CLI defaults: {exc}")
-        return KoffeeConfig()
-
-
-defaults = _load_cli_defaults()
-
-
-def _create_progress_bar() -> Progress:
-    """Creates a rich progress bar for tracking transcription and translation."""
-    return Progress(
-        SpinnerColumn(),
-        TextColumn("[bold blue]{task.description}"),
-        BarColumn(),
-        TextColumn("{task.percentage:>3.0f}%"),
-        TimeElapsedColumn(),
-    )
-
-
-def _make_progress_callback(progress: Progress, task_id) -> callable:
-    """Returns a callback that updates a progress bar given a 0.0-1.0 ratio."""
-
-    def callback(ratio: float) -> None:
-        progress.update(task_id, completed=ratio * 100)
-
-    return callback
 
 
 @app.default()
@@ -260,67 +202,6 @@ def _print_dry_run(resolved_paths: list[Path], config: KoffeeConfig) -> None:
         log.info(f"[dry-run] Subtitles will be embedded into video ({config.embed})")
 
 
-def _handle_embedded_subtitles(video_path: Path, config: KoffeeConfig) -> KoffeeConfig:
-    """If the video has embedded subtitles, prompts the user and updates config."""
-    tracks = _detect_embedded_subtitles(video_path)
-    if not tracks:
-        return config
-
-    log.info(f"Found {len(tracks)} embedded subtitle track(s) in {video_path.name}.")
-    if not _prompt_use_embedded_subtitles():
-        return config
-
-    return _apply_subtitle_track(config, tracks)
-
-
-def _apply_subtitle_track(config: KoffeeConfig, tracks: list[dict]) -> KoffeeConfig:
-    """Selects a subtitle track and returns an updated config."""
-    track_index, source_language = _select_subtitle_track(tracks)
-    updates = {"use_embedded_subtitles": True, "subtitle_track_index": track_index}
-    if source_language:
-        updates["source_language"] = source_language
-
-    return config.model_copy(update=updates)
-
-
-def _detect_embedded_subtitles(video_path: Path) -> list[dict]:
-    """Returns embedded subtitle tracks in the video, or an empty list."""
-    if video_path.suffix.lower() in SUBTITLE_EXTENSIONS:
-        return []
-
-    return get_subtitle_tracks(video_path)
-
-
-def _prompt_use_embedded_subtitles() -> bool:
-    """Prompts the user to use embedded subtitles instead of running ASR."""
-    user_input = input("Translate embedded subtitles instead of running ASR? [Y/n] ")
-    return user_input.strip().lower() in ("", "y", "yes")
-
-
-def _select_subtitle_track(tracks: list[dict]) -> tuple[int, str | None]:
-    """Prompts user to select a subtitle track if multiple are available."""
-    if len(tracks) == 1:
-        language = tracks[0].get("tags", {}).get("language")
-        return 0, language
-
-    log.info("Available subtitle tracks:")
-    for i, track in enumerate(tracks):
-        tags = track.get("tags", {})
-        language = tags.get("language", "unknown")
-        title = tags.get("title", "")
-        label = f"  [{i}] {language}"
-        if title:
-            label += f" — {title}"
-        log.info(label)
-
-    user_input = input(f"Select track [0-{len(tracks) - 1}] (default 0): ")
-    index = int(user_input.strip()) if user_input.strip().isdigit() else 0
-    index = max(0, min(index, len(tracks) - 1))
-
-    language = tracks[index].get("tags", {}).get("language")
-    return index, language
-
-
 def _resolve_paths(file_path: tuple) -> list[Path]:
     """Resolves glob patterns, directories, and files into a flat list of paths."""
     resolved_paths = []
@@ -393,93 +274,43 @@ def _translate_with_progress(
 
 
 @app.command()
-def info() -> None:
-    """Display system information for debugging."""
-    log.info("[koffee info]")
-
-    ffmpeg_path = shutil.which("ffmpeg")
-    if ffmpeg_path:
-        result = subprocess.run(
-            ["ffmpeg", "-version"],
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        version_line = result.stdout.split("\n")[0]
-        log.info(f"  ffmpeg: {version_line}")
-    else:
-        log.info("  ffmpeg: not found")
-
-    ffprobe_path = shutil.which("ffprobe")
-    log.info(f"  ffprobe: {'found' if ffprobe_path else 'not found'}")
-
-    try:
-        import torch  # noqa: PLC0415
-
-        cuda_available = torch.cuda.is_available()
-        device_name = torch.cuda.get_device_name(0) if cuda_available else "N/A"
-        log.info(f"  CUDA: {'available' if cuda_available else 'not available'}")
-        if cuda_available:
-            log.info(f"  GPU: {device_name}")
-    except ImportError:
-        log.info("  torch: not installed")
-
-    config = KoffeeConfig(**load_config_file())
-    log.info(f"  default whisper model: {config.whisper_model}")
-    log.info(f"  default backend: {config.provider}")
-    log.info(f"  config file: {_find_config_path() or 'none'}")
-
-
-@app.command()
-def languages() -> None:
-    """List all supported language codes."""
-    num_columns = 4
-    codes = sorted(LANGUAGE_CODES - {"auto"})
-    entries = [f"{code} ({LANGUAGE_NAMES.get(code, code)})" for code in codes]
-
-    table = Table(show_header=False, box=None, pad_edge=False, expand=True)
-    for _ in range(num_columns):
-        table.add_column()
-
-    for i in range(0, len(entries), num_columns):
-        row = entries[i : i + num_columns]
-        row += [""] * (num_columns - len(row))
-        table.add_row(*row)
-
-    console = Console()
-    console.print(table)
-    console.print(f"\n[bold]{len(codes)}[/bold] supported languages")
-
-
-def _find_config_path() -> Path | None:
-    """Returns the path to the active config file, or None."""
-    for path in CONFIG_SEARCH_PATHS:
-        if path.is_file():
-            return path
-    return None
-
-
-@app.command()
-def tracks(
+def convert(
     file_path: Annotated[Path, Parameter(validator=validators.Path(exists=True))],
+    subtitle_format: Annotated[str, Parameter(name=("--format", "-f"))] = "vtt",
+    output_dir: Annotated[Path, Parameter(name=("--output-dir", "-o"))] | None = None,
+    output_name: Annotated[str, Parameter(name=("--output-name", "-n"))] | None = None,
+    overwrite: Annotated[
+        bool, Parameter(name=("--overwrite",), group=options_group)
+    ] = False,
 ) -> None:
-    """List embedded subtitle tracks in a video file."""
-    track_list = get_subtitle_tracks(file_path)
+    """Convert a subtitle file between formats (SRT, VTT, ASS).
 
-    if not track_list:
-        log.info(f"No subtitle tracks found in {file_path.name}.")
-        return
+    Parameters
+    ----------
+    file_path: Path
+        Path to the subtitle file
+    subtitle_format: str
+        Target subtitle format (srt, vtt, or ass)
+    output_dir: Path
+        Directory for the output file
+    output_name: str
+        Name of the output file
+    overwrite: bool
+        Overwrite existing output files instead of raising an error
+    """
+    segments = parse_subtitle_file(file_path)
+    out_dir = output_dir if output_dir is not None else file_path.parent
+    subtitle_path = generate_subtitles(subtitle_format, segments, out_dir)
 
-    log.info(f"Subtitle tracks in {file_path.name}:")
-    for i, track in enumerate(track_list):
-        tags = track.get("tags", {})
-        language = tags.get("language", "unknown")
-        title = tags.get("title", "")
-        label = f"  [{i}] {language}"
-        if title:
-            label += f" — {title}"
-        log.info(label)
+    target_path = _write_output(
+        subtitle_path,
+        file_path,
+        subtitle_format,
+        output_dir,
+        output_name,
+        overwrite,
+    )
+    log.info(f"Converted {file_path.name} to {target_path}")
 
 
 @app.command()
@@ -518,6 +349,96 @@ def embed(
 
     result = embed_subtitles(subtitle_path, video_path, output_path, mode=mode)
     log.info(f"Output saved to {result}")
+
+
+@app.command()
+def info() -> None:
+    """Display system information for debugging."""
+    log.info("[koffee info]")
+
+    ffmpeg_path = shutil.which("ffmpeg")
+    if ffmpeg_path:
+        result = subprocess.run(
+            ["ffmpeg", "-version"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        version_line = result.stdout.split("\n")[0]
+        log.info(f"  ffmpeg: {version_line}")
+    else:
+        log.info("  ffmpeg: not found")
+
+    ffprobe_path = shutil.which("ffprobe")
+    log.info(f"  ffprobe: {'found' if ffprobe_path else 'not found'}")
+
+    try:
+        import torch  # noqa: PLC0415
+
+        cuda_available = torch.cuda.is_available()
+        device_name = torch.cuda.get_device_name(0) if cuda_available else "N/A"
+        log.info(f"  CUDA: {'available' if cuda_available else 'not available'}")
+        if cuda_available:
+            log.info(f"  GPU: {device_name}")
+    except ImportError:
+        log.info("  torch: not installed")
+
+    config = KoffeeConfig(**load_config_file())
+    log.info(f"  default whisper model: {config.whisper_model}")
+    log.info(f"  default backend: {config.provider}")
+    log.info(f"  config file: {_find_config_path() or 'none'}")
+
+
+def _find_config_path() -> Path | None:
+    """Returns the path to the active config file, or None."""
+    for path in CONFIG_SEARCH_PATHS:
+        if path.is_file():
+            return path
+    return None
+
+
+@app.command()
+def languages() -> None:
+    """List all supported language codes."""
+    num_columns = 4
+    codes = sorted(LANGUAGE_CODES - {"auto"})
+    entries = [f"{code} ({LANGUAGE_NAMES.get(code, code)})" for code in codes]
+
+    table = Table(show_header=False, box=None, pad_edge=False, expand=True)
+    for _ in range(num_columns):
+        table.add_column()
+
+    for i in range(0, len(entries), num_columns):
+        row = entries[i : i + num_columns]
+        row += [""] * (num_columns - len(row))
+        table.add_row(*row)
+
+    console = Console()
+    console.print(table)
+    console.print(f"\n[bold]{len(codes)}[/bold] supported languages")
+
+
+@app.command()
+def tracks(
+    file_path: Annotated[Path, Parameter(validator=validators.Path(exists=True))],
+) -> None:
+    """List embedded subtitle tracks in a video file."""
+    track_list = get_subtitle_tracks(file_path)
+
+    if not track_list:
+        log.info(f"No subtitle tracks found in {file_path.name}.")
+        return
+
+    log.info(f"Subtitle tracks in {file_path.name}:")
+    for i, track in enumerate(track_list):
+        tags = track.get("tags", {})
+        language = tags.get("language", "unknown")
+        title = tags.get("title", "")
+        label = f"  [{i}] {language}"
+        if title:
+            label += f" — {title}"
+        log.info(label)
 
 
 @app.command()
@@ -594,46 +515,6 @@ def transcribe(
     log.info(f"Output saved to {target_path}")
 
 
-@app.command()
-def convert(
-    file_path: Annotated[Path, Parameter(validator=validators.Path(exists=True))],
-    subtitle_format: Annotated[str, Parameter(name=("--format", "-f"))] = "vtt",
-    output_dir: Annotated[Path, Parameter(name=("--output-dir", "-o"))] | None = None,
-    output_name: Annotated[str, Parameter(name=("--output-name", "-n"))] | None = None,
-    overwrite: Annotated[
-        bool, Parameter(name=("--overwrite",), group=options_group)
-    ] = False,
-) -> None:
-    """Convert a subtitle file between formats (SRT, VTT, ASS).
-
-    Parameters
-    ----------
-    file_path: Path
-        Path to the subtitle file
-    subtitle_format: str
-        Target subtitle format (srt, vtt, or ass)
-    output_dir: Path
-        Directory for the output file
-    output_name: str
-        Name of the output file
-    overwrite: bool
-        Overwrite existing output files instead of raising an error
-    """
-    segments = parse_subtitle_file(file_path)
-    out_dir = output_dir if output_dir is not None else file_path.parent
-    subtitle_path = generate_subtitles(subtitle_format, segments, out_dir)
-
-    target_path = _write_output(
-        subtitle_path,
-        file_path,
-        subtitle_format,
-        output_dir,
-        output_name,
-        overwrite,
-    )
-    log.info(f"Converted {file_path.name} to {target_path}")
-
-
 app["info"].sort_key = 0
 app["languages"].sort_key = 1
 app["tracks"].sort_key = 2
@@ -645,7 +526,3 @@ app["embed"].sort_key = 5
 def main() -> None:
     """Wraps app() so that it is accessible to poetry."""
     app()
-
-
-if __name__ == "__main__":
-    main()

--- a/koffee/cli/embedded.py
+++ b/koffee/cli/embedded.py
@@ -1,0 +1,69 @@
+"""Embedded subtitle detection and track selection for the CLI."""
+
+from pathlib import Path
+
+from koffee.api import SUBTITLE_EXTENSIONS
+from koffee.cli.app import log
+from koffee.schemas.config import KoffeeConfig
+from koffee.utils import get_subtitle_tracks
+
+
+def _handle_embedded_subtitles(video_path: Path, config: KoffeeConfig) -> KoffeeConfig:
+    """If the video has embedded subtitles, prompts the user and updates config."""
+    tracks = _detect_embedded_subtitles(video_path)
+    if not tracks:
+        return config
+
+    log.info(f"Found {len(tracks)} embedded subtitle track(s) in {video_path.name}.")
+    if not _prompt_use_embedded_subtitles():
+        return config
+
+    return _apply_subtitle_track(config, tracks)
+
+
+def _apply_subtitle_track(config: KoffeeConfig, tracks: list[dict]) -> KoffeeConfig:
+    """Selects a subtitle track and returns an updated config."""
+    track_index, source_language = _select_subtitle_track(tracks)
+    updates = {"use_embedded_subtitles": True, "subtitle_track_index": track_index}
+    if source_language:
+        updates["source_language"] = source_language
+
+    return config.model_copy(update=updates)
+
+
+def _detect_embedded_subtitles(video_path: Path) -> list[dict]:
+    """Returns embedded subtitle tracks in the video, or an empty list."""
+    if video_path.suffix.lower() in SUBTITLE_EXTENSIONS:
+        return []
+
+    return get_subtitle_tracks(video_path)
+
+
+def _prompt_use_embedded_subtitles() -> bool:
+    """Prompts the user to use embedded subtitles instead of running ASR."""
+    user_input = input("Translate embedded subtitles instead of running ASR? [Y/n] ")
+    return user_input.strip().lower() in ("", "y", "yes")
+
+
+def _select_subtitle_track(tracks: list[dict]) -> tuple[int, str | None]:
+    """Prompts user to select a subtitle track if multiple are available."""
+    if len(tracks) == 1:
+        language = tracks[0].get("tags", {}).get("language")
+        return 0, language
+
+    log.info("Available subtitle tracks:")
+    for i, track in enumerate(tracks):
+        tags = track.get("tags", {})
+        language = tags.get("language", "unknown")
+        title = tags.get("title", "")
+        label = f"  [{i}] {language}"
+        if title:
+            label += f" — {title}"
+        log.info(label)
+
+    user_input = input(f"Select track [0-{len(tracks) - 1}] (default 0): ")
+    index = int(user_input.strip()) if user_input.strip().isdigit() else 0
+    index = max(0, min(index, len(tracks) - 1))
+
+    language = tracks[index].get("tags", {}).get("language")
+    return index, language

--- a/koffee/cli/progress.py
+++ b/koffee/cli/progress.py
@@ -1,0 +1,29 @@
+"""Progress bar helpers for CLI commands."""
+
+from rich.progress import (
+    BarColumn,
+    Progress,
+    SpinnerColumn,
+    TextColumn,
+    TimeElapsedColumn,
+)
+
+
+def _create_progress_bar() -> Progress:
+    """Creates a rich progress bar for tracking transcription and translation."""
+    return Progress(
+        SpinnerColumn(),
+        TextColumn("[bold blue]{task.description}"),
+        BarColumn(),
+        TextColumn("{task.percentage:>3.0f}%"),
+        TimeElapsedColumn(),
+    )
+
+
+def _make_progress_callback(progress: Progress, task_id) -> callable:
+    """Returns a callback that updates a progress bar given a 0.0-1.0 ratio."""
+
+    def callback(ratio: float) -> None:
+        progress.update(task_id, completed=ratio * 100)
+
+    return callback

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,7 +32,7 @@ output_file_name = "cli_output_video_file"
 
 def test_cli(mocker: MockerFixture) -> None:
     """Tests that CLI processes a valid video file."""
-    mock_translate = mocker.patch("koffee.cli.run")
+    mock_translate = mocker.patch("koffee.cli.commands.run")
 
     cli(
         korean_video_path,
@@ -51,9 +51,11 @@ def test_cli(mocker: MockerFixture) -> None:
 
 def test_script_run() -> None:
     """Tests that the CLI script runs."""
-    cli_path = Path("koffee/cli.py")
     result = subprocess.run(
-        [sys.executable, cli_path], check=False, capture_output=True, text=True
+        [sys.executable, "-m", "koffee.cli"],
+        check=False,
+        capture_output=True,
+        text=True,
     )
 
     assert result.returncode == 0
@@ -61,7 +63,7 @@ def test_script_run() -> None:
 
 def test_embed_soft(mocker: MockerFixture) -> None:
     """Tests that embed flag is passed through to config."""
-    mock_translate = mocker.patch("koffee.cli.run")
+    mock_translate = mocker.patch("koffee.cli.commands.run")
 
     cli(
         korean_video_path,
@@ -79,7 +81,7 @@ def test_embed_soft(mocker: MockerFixture) -> None:
 
 def test_embed_defaults_to_none(mocker: MockerFixture) -> None:
     """Tests that embed defaults to none."""
-    mock_translate = mocker.patch("koffee.cli.run")
+    mock_translate = mocker.patch("koffee.cli.commands.run")
 
     cli(
         korean_video_path,
@@ -96,7 +98,7 @@ def test_embed_defaults_to_none(mocker: MockerFixture) -> None:
 
 def test_verbose(mocker: MockerFixture) -> None:
     """Tests if verbose flag sets log level to DEBUG."""
-    mocker.patch("koffee.cli.run")
+    mocker.patch("koffee.cli.commands.run")
     mock_logger = mocker.patch("logging.getLogger")
     logger_instance = mock_logger.return_value
 
@@ -147,8 +149,8 @@ def test_resolve_paths_glob_no_match(tmp_path, monkeypatch) -> None:
 
 def test_dry_run(mocker: MockerFixture) -> None:
     """Tests that dry-run previews actions without translating."""
-    mock_translate = mocker.patch("koffee.cli.run")
-    mocker.patch("koffee.cli.get_subtitle_tracks", return_value=[])
+    mock_translate = mocker.patch("koffee.cli.commands.run")
+    mocker.patch("koffee.cli.embedded.get_subtitle_tracks", return_value=[])
 
     cli(
         korean_video_path,
@@ -161,8 +163,8 @@ def test_dry_run(mocker: MockerFixture) -> None:
 
 def test_dry_run_subtitle_file(mocker: MockerFixture, tmp_path) -> None:
     """Tests that dry-run shows subtitle translation mode for .srt files."""
-    mock_translate = mocker.patch("koffee.cli.run")
-    mocker.patch("koffee.cli.get_subtitle_tracks", return_value=[])
+    mock_translate = mocker.patch("koffee.cli.commands.run")
+    mocker.patch("koffee.cli.embedded.get_subtitle_tracks", return_value=[])
     srt = tmp_path / "test.srt"
     srt.touch()
 
@@ -173,8 +175,8 @@ def test_dry_run_subtitle_file(mocker: MockerFixture, tmp_path) -> None:
 
 def test_dry_run_with_embed(mocker: MockerFixture) -> None:
     """Tests that dry-run shows embed info when flag is set."""
-    mocker.patch("koffee.cli.run")
-    mocker.patch("koffee.cli.get_subtitle_tracks", return_value=[])
+    mocker.patch("koffee.cli.commands.run")
+    mocker.patch("koffee.cli.embedded.get_subtitle_tracks", return_value=[])
 
     cli(
         korean_video_path,
@@ -201,7 +203,7 @@ def test_handle_embedded_subtitles_no_tracks(
     mocker: MockerFixture,
 ) -> None:
     """Tests that videos with no subtitle tracks return config unchanged."""
-    mocker.patch("koffee.cli.get_subtitle_tracks", return_value=[])
+    mocker.patch("koffee.cli.embedded.get_subtitle_tracks", return_value=[])
     config = KoffeeConfig()
 
     result = _handle_embedded_subtitles(korean_video_path, config)
@@ -214,7 +216,7 @@ def test_handle_embedded_subtitles_user_accepts(
 ) -> None:
     """Tests that accepting embedded subtitles updates config."""
     tracks = [{"index": 0, "codec": "srt", "tags": {"language": "ko"}}]
-    mocker.patch("koffee.cli.get_subtitle_tracks", return_value=tracks)
+    mocker.patch("koffee.cli.embedded.get_subtitle_tracks", return_value=tracks)
     mocker.patch("builtins.input", return_value="y")
     config = KoffeeConfig()
 
@@ -229,7 +231,7 @@ def test_handle_embedded_subtitles_user_declines(
 ) -> None:
     """Tests that declining embedded subtitles keeps config unchanged."""
     mocker.patch(
-        "koffee.cli.get_subtitle_tracks",
+        "koffee.cli.embedded.get_subtitle_tracks",
         return_value=[{"index": 0, "codec": "srt"}],
     )
     mocker.patch("builtins.input", return_value="n")
@@ -242,8 +244,8 @@ def test_handle_embedded_subtitles_user_declines(
 
 def test_translate_with_progress_subtitle_file(mocker: MockerFixture, tmp_path) -> None:
     """Tests that subtitle files skip the ASR progress bar."""
-    mock_translate = mocker.patch("koffee.cli.run")
-    mocker.patch("koffee.cli.get_subtitle_tracks", return_value=[])
+    mock_translate = mocker.patch("koffee.cli.commands.run")
+    mocker.patch("koffee.cli.embedded.get_subtitle_tracks", return_value=[])
     srt = tmp_path / "test.srt"
     srt.touch()
 
@@ -257,9 +259,9 @@ def test_translate_with_progress_subtitle_file(mocker: MockerFixture, tmp_path) 
 
 def test_batch_progress_logging(mocker: MockerFixture) -> None:
     """Tests that batch processing logs progress for multiple files."""
-    mock_translate = mocker.patch("koffee.cli.run")
-    mocker.patch("koffee.cli.get_subtitle_tracks", return_value=[])
-    mock_log = mocker.patch("koffee.cli.log")
+    mock_translate = mocker.patch("koffee.cli.commands.run")
+    mocker.patch("koffee.cli.embedded.get_subtitle_tracks", return_value=[])
+    mock_log = mocker.patch("koffee.cli.commands.log")
 
     cli(
         korean_video_path,
@@ -275,9 +277,9 @@ def test_batch_progress_logging(mocker: MockerFixture) -> None:
 
 def test_batch_summary_on_success(mocker: MockerFixture) -> None:
     """Tests that batch processing logs a summary when all files succeed."""
-    mocker.patch("koffee.cli.run")
-    mocker.patch("koffee.cli.get_subtitle_tracks", return_value=[])
-    mock_log = mocker.patch("koffee.cli.log")
+    mocker.patch("koffee.cli.commands.run")
+    mocker.patch("koffee.cli.embedded.get_subtitle_tracks", return_value=[])
+    mock_log = mocker.patch("koffee.cli.commands.log")
 
     cli(
         korean_video_path,
@@ -291,9 +293,9 @@ def test_batch_summary_on_success(mocker: MockerFixture) -> None:
 
 def test_batch_summary_on_partial_failure(mocker: MockerFixture) -> None:
     """Tests that batch processing logs failed files in the summary."""
-    mocker.patch("koffee.cli.run", side_effect=[None, KoffeeError("boom")])
-    mocker.patch("koffee.cli.get_subtitle_tracks", return_value=[])
-    mock_log = mocker.patch("koffee.cli.log")
+    mocker.patch("koffee.cli.commands.run", side_effect=[None, KoffeeError("boom")])
+    mocker.patch("koffee.cli.embedded.get_subtitle_tracks", return_value=[])
+    mock_log = mocker.patch("koffee.cli.commands.log")
 
     cli(
         korean_video_path,
@@ -310,8 +312,8 @@ def test_batch_summary_on_partial_failure(mocker: MockerFixture) -> None:
 
 def test_prompt_flag(mocker: MockerFixture) -> None:
     """Tests that --prompt is passed through to config."""
-    mock_translate = mocker.patch("koffee.cli.run")
-    mocker.patch("koffee.cli.get_subtitle_tracks", return_value=[])
+    mock_translate = mocker.patch("koffee.cli.commands.run")
+    mocker.patch("koffee.cli.embedded.get_subtitle_tracks", return_value=[])
 
     cli(
         korean_video_path,
@@ -329,8 +331,8 @@ def test_config_flag_loads_file(mocker: MockerFixture, tmp_path) -> None:
     config_file = tmp_path / "custom.toml"
     config_file.write_text('target_language = "fr"\n')
 
-    mock_translate = mocker.patch("koffee.cli.run")
-    mocker.patch("koffee.cli.get_subtitle_tracks", return_value=[])
+    mock_translate = mocker.patch("koffee.cli.commands.run")
+    mocker.patch("koffee.cli.embedded.get_subtitle_tracks", return_value=[])
 
     cli(
         korean_video_path,
@@ -393,9 +395,9 @@ def test_select_subtitle_track_missing_language_tag() -> None:
 
 def test_info_command(mocker: MockerFixture) -> None:
     """Tests that info command runs without error."""
-    mocker.patch("koffee.cli.shutil.which", return_value="/usr/bin/ffmpeg")
+    mocker.patch("koffee.cli.commands.shutil.which", return_value="/usr/bin/ffmpeg")
     mocker.patch(
-        "koffee.cli.subprocess.run",
+        "koffee.cli.commands.subprocess.run",
         return_value=subprocess.CompletedProcess(
             args=[], returncode=0, stdout="ffmpeg version 7.0\n"
         ),
@@ -406,7 +408,7 @@ def test_info_command(mocker: MockerFixture) -> None:
 
 def test_info_command_no_ffmpeg(mocker: MockerFixture) -> None:
     """Tests that info command handles missing ffmpeg."""
-    mocker.patch("koffee.cli.shutil.which", return_value=None)
+    mocker.patch("koffee.cli.commands.shutil.which", return_value=None)
 
     info()
 
@@ -414,7 +416,7 @@ def test_info_command_no_ffmpeg(mocker: MockerFixture) -> None:
 def test_tracks_command(mocker: MockerFixture) -> None:
     """Tests that tracks command lists subtitle tracks."""
     mocker.patch(
-        "koffee.cli.get_subtitle_tracks",
+        "koffee.cli.commands.get_subtitle_tracks",
         return_value=[
             {"index": 0, "tags": {"language": "ja", "title": "Japanese"}},
             {"index": 1, "tags": {"language": "en"}},
@@ -426,7 +428,7 @@ def test_tracks_command(mocker: MockerFixture) -> None:
 
 def test_tracks_command_no_tracks(mocker: MockerFixture) -> None:
     """Tests that tracks command handles no subtitle tracks."""
-    mocker.patch("koffee.cli.get_subtitle_tracks", return_value=[])
+    mocker.patch("koffee.cli.commands.get_subtitle_tracks", return_value=[])
 
     tracks(korean_video_path)
 
@@ -434,7 +436,7 @@ def test_tracks_command_no_tracks(mocker: MockerFixture) -> None:
 def test_find_config_path_returns_none(monkeypatch) -> None:
     """Tests that _find_config_path returns None when no config exists."""
     monkeypatch.setattr(
-        "koffee.cli.CONFIG_SEARCH_PATHS",
+        "koffee.cli.commands.CONFIG_SEARCH_PATHS",
         [Path("/nonexistent/koffee.toml")],
     )
 
@@ -449,7 +451,9 @@ def test_embed_command(mocker: MockerFixture, tmp_path) -> None:
     sub.touch()
     output = tmp_path / "out.mp4"
 
-    mock_embed = mocker.patch("koffee.cli.embed_subtitles", return_value=output)
+    mock_embed = mocker.patch(
+        "koffee.cli.commands.embed_subtitles", return_value=output
+    )
 
     embed(video, sub, output_path=output)
 
@@ -464,7 +468,9 @@ def test_embed_command_hard_mode(mocker: MockerFixture, tmp_path) -> None:
     sub.touch()
     output = tmp_path / "out.mp4"
 
-    mock_embed = mocker.patch("koffee.cli.embed_subtitles", return_value=output)
+    mock_embed = mocker.patch(
+        "koffee.cli.commands.embed_subtitles", return_value=output
+    )
 
     embed(video, sub, output_path=output, mode="hard")
 
@@ -480,7 +486,7 @@ def test_embed_command_default_output(mocker: MockerFixture, tmp_path) -> None:
     expected_output = tmp_path / "video_embed.mp4"
 
     mock_embed = mocker.patch(
-        "koffee.cli.embed_subtitles", return_value=expected_output
+        "koffee.cli.commands.embed_subtitles", return_value=expected_output
     )
 
     embed(video, sub)
@@ -509,14 +515,14 @@ def test_transcribe_command(mocker: MockerFixture, tmp_path) -> None:
     subtitle_file.touch()
 
     mocker.patch(
-        "koffee.cli.asr.transcribe",
+        "koffee.cli.commands.asr.transcribe",
         return_value={
             "segments": [{"start": 0.0, "end": 1.0, "text": "Hello."}],
             "language": "en",
         },
     )
     mocker.patch(
-        "koffee.cli.generate_subtitles",
+        "koffee.cli.commands.generate_subtitles",
         return_value=subtitle_file,
     )
     mocker.patch("pathlib.Path.replace")
@@ -534,14 +540,14 @@ def test_transcribe_command_collision(mocker: MockerFixture, tmp_path) -> None:
     subtitle_file.touch()
 
     mocker.patch(
-        "koffee.cli.asr.transcribe",
+        "koffee.cli.commands.asr.transcribe",
         return_value={
             "segments": [{"start": 0.0, "end": 1.0, "text": "Hello."}],
             "language": "en",
         },
     )
     mocker.patch(
-        "koffee.cli.generate_subtitles",
+        "koffee.cli.commands.generate_subtitles",
         return_value=subtitle_file,
     )
 
@@ -557,11 +563,11 @@ def test_convert_command(mocker: MockerFixture, tmp_path) -> None:
     subtitle_file.touch()
 
     mock_parse = mocker.patch(
-        "koffee.cli.parse_subtitle_file",
+        "koffee.cli.commands.parse_subtitle_file",
         return_value=[{"start": 0.0, "end": 1.0, "text": "Hello."}],
     )
     mocker.patch(
-        "koffee.cli.generate_subtitles",
+        "koffee.cli.commands.generate_subtitles",
         return_value=subtitle_file,
     )
     mocker.patch("pathlib.Path.replace")
@@ -579,11 +585,11 @@ def test_convert_command_default_output(mocker: MockerFixture, tmp_path) -> None
     subtitle_file.touch()
 
     mocker.patch(
-        "koffee.cli.parse_subtitle_file",
+        "koffee.cli.commands.parse_subtitle_file",
         return_value=[{"start": 0.0, "end": 1.0, "text": "Hello."}],
     )
     mocker.patch(
-        "koffee.cli.generate_subtitles",
+        "koffee.cli.commands.generate_subtitles",
         return_value=subtitle_file,
     )
     mocker.patch("pathlib.Path.replace")
@@ -601,11 +607,11 @@ def test_convert_command_collision(mocker: MockerFixture, tmp_path) -> None:
     subtitle_file.touch()
 
     mocker.patch(
-        "koffee.cli.parse_subtitle_file",
+        "koffee.cli.commands.parse_subtitle_file",
         return_value=[{"start": 0.0, "end": 1.0, "text": "Hello."}],
     )
     mocker.patch(
-        "koffee.cli.generate_subtitles",
+        "koffee.cli.commands.generate_subtitles",
         return_value=subtitle_file,
     )
 


### PR DESCRIPTION
## Summary
Splits the 650-line `koffee/cli.py` into a `koffee/cli/` package with `app` (cyclopts `App`, groups, logging, defaults), `commands` (all `@app.command` definitions, the default `cli`, and its private helpers), `embedded` (subtitle-track detection and prompting), and `progress` (rich progress-bar helpers). `__init__.py` re-exports the public entry points so the `koffee.cli:main` script target still resolves, and a new `__main__.py` enables `python -m koffee.cli`. Test patches are rescoped to the submodule where each symbol is actually bound, since re-exports on the package don't affect a submodule's local name.