### PR TITLE
Adopt stepdown function ordering across koffee modules

### DIFF
--- a/koffee/api.py
+++ b/koffee/api.py
@@ -60,12 +60,234 @@ def run(
     return output_path
 
 
-def _validate_file(input_path: Path | str) -> None:
-    """Raises InvalidVideoFileError if the file does not exist or is not a file."""
-    if not Path(input_path).exists() or not Path(input_path).is_file():
-        error_message = "Input file is not valid or does not exist."
-        log.error(error_message)
-        raise InvalidVideoFileError(error_message)
+def _apply_config_overrides(config: KoffeeConfig | None, kwargs: dict) -> KoffeeConfig:
+    """Resolves config, applying any kwarg overrides on top of an existing config."""
+    if config is None:
+        config = KoffeeConfig(**kwargs)
+    else:
+        config = KoffeeConfig(**{**config.model_dump(), **kwargs})
+
+    return config
+
+
+def _route_output(
+    input_path: Path | str,
+    subtitle_path: Path,
+    config: KoffeeConfig,
+) -> Path:
+    """Routes to subtitle output or video embed based on file type and config."""
+    is_audio = Path(input_path).suffix.lower() in AUDIO_EXTENSIONS
+    has_embed = not is_audio and config.embed != "none"
+
+    output_path = _get_output_path(
+        input_path, config.output_dir, config.output_name, date_suffix=has_embed
+    )
+
+    if has_embed:
+        _check_output_collision(output_path, config.overwrite)
+        result_path = _finalize_video_output(
+            subtitle_path,
+            input_path,
+            output_path,
+            config.embed,
+            config.target_language,
+        )
+    else:
+        result_path = _write_output(
+            subtitle_path,
+            input_path,
+            config.subtitle_format,
+            config.output_dir,
+            config.output_name,
+            config.overwrite,
+        )
+
+    return result_path
+
+
+def _finalize_video_output(
+    subtitle_path: Path,
+    input_path: Path,
+    output_path: Path,
+    embed_mode: str = "soft",
+    language: str = "en",
+) -> Path:
+    """Embeds subtitles into the video and deletes the subtitle file after."""
+    output_video = embed_subtitles(
+        subtitle_path,
+        input_path,
+        output_path,
+        mode=embed_mode,
+        language=language,
+    )
+    subtitle_path.unlink()
+    log.info("Finished processing video!")
+
+    return output_video
+
+
+def _write_output(
+    source_path: Path,
+    input_path: Path | str,
+    subtitle_format: str,
+    output_dir: Path | None,
+    output_name: str | None,
+    overwrite: bool,
+) -> Path:
+    """Moves a generated subtitle file to its resolved output location."""
+    base_path = _get_output_path(input_path, output_dir, output_name)
+    target_path = base_path.with_suffix(f".{subtitle_format}")
+
+    try:
+        _check_output_collision(target_path, overwrite)
+    except FileExistsError:
+        source_path.unlink(missing_ok=True)
+        raise
+
+    source_path.replace(target_path)
+    log.info("Finished processing file!")
+
+    return target_path
+
+
+def _check_output_collision(output_path: Path, overwrite: bool) -> None:
+    """Raises FileExistsError if the output file exists and overwrite is disabled."""
+    if output_path.exists() and not overwrite:
+        error_message = (
+            f"Output file already exists: {output_path}. Use --overwrite to replace it."
+        )
+        raise FileExistsError(error_message)
+
+
+def _get_output_path(
+    input_path: Path | str,
+    output_dir: Path | None,
+    output_name: str | None,
+    date_suffix: bool = False,
+) -> Path:
+    """Gets the output path for the translated output file."""
+    log.debug(f"output_name: {output_name!r}")
+
+    file_path = Path(input_path)
+    file_dir = output_dir if output_dir is not None else file_path.parent
+    file_dir.mkdir(parents=True, exist_ok=True)
+
+    if output_name is not None:
+        file_name = output_name
+    elif date_suffix:
+        file_name = f"{file_path.stem}_{datetime.now().strftime('%m-%d-%Y')}"
+    else:
+        file_name = file_path.stem
+
+    output_path = file_dir / (file_name + file_path.suffix)
+    log.debug(f"output_dir: {output_path!r}")
+
+    return output_path
+
+
+def _transcribe(
+    input_path: Path | str,
+    config: KoffeeConfig,
+    on_progress: Callable[[float], None] | None,
+) -> Transcript:
+    """Transcribes audio from the file, returning the raw transcript."""
+    transcript = transcribe(
+        str(input_path),
+        config.compute_type,
+        config.device,
+        config.whisper_model,
+        config.provider,
+        on_progress=on_progress,
+        vad_filter=config.vad_filter,
+    )
+
+    return transcript
+
+
+def _translate(
+    transcript: Transcript,
+    config: KoffeeConfig,
+    on_progress: Callable[[float], None] | None,
+) -> Path:
+    """Translates transcript segments and writes the subtitle file."""
+    segments = _get_segments(transcript, config, on_progress=on_progress)
+    subtitle_path = generate_subtitles(config.subtitle_format, segments)
+
+    return subtitle_path
+
+
+def _get_segments(
+    transcript: Transcript,
+    config: KoffeeConfig,
+    on_progress: Callable[[float], None] | None = None,
+) -> list[Segment]:
+    """Returns translated or raw segments based on the translation backend."""
+    if config.provider == "whisper":
+        segments = transcript["segments"]
+    else:
+        segments = translate(
+            transcript,
+            config.target_language,
+            config.api_key,
+            on_progress,
+            llm_model=config.llm_model,
+            prompt=config.prompt,
+            provider=config.provider,
+            chunk_size=config.chunk_size,
+            context_size=config.context_size,
+            sleep_requests=config.sleep_requests,
+        )
+
+    return segments
+
+
+def _translate_embedded_subtitles(
+    input_path: Path | str,
+    config: KoffeeConfig,
+    on_progress: Callable[[float], None] | None,
+) -> Path:
+    """Extracts embedded subtitles from a video and translates them."""
+    log.info("Extracting embedded subtitles from video.")
+
+    extracted_path = extract_subtitle_track(input_path, config.subtitle_track_index)
+    try:
+        result = _translate_subtitle_file(extracted_path, config, on_progress)
+    finally:
+        extracted_path.unlink(missing_ok=True)
+
+    return result
+
+
+def _translate_subtitle_file(
+    file_path: Path | str,
+    config: KoffeeConfig,
+    on_progress: Callable[[float], None] | None,
+) -> Path:
+    """Translates an existing subtitle file without ASR."""
+    log.info("Detected subtitle file input, skipping transcription.")
+
+    segments = parse_subtitle_file(file_path)
+    translated_segments = translate(
+        {"segments": segments, "language": config.source_language},
+        config.target_language,
+        config.api_key,
+        on_progress,
+        llm_model=config.llm_model,
+        prompt=config.prompt,
+        provider=config.provider,
+        sleep_requests=config.sleep_requests,
+    )
+    translated_path = generate_subtitles(config.subtitle_format, translated_segments)
+    output_subtitle_path = _write_output(
+        translated_path,
+        file_path,
+        config.subtitle_format,
+        config.output_dir,
+        config.output_name,
+        config.overwrite,
+    )
+
+    return output_subtitle_path
 
 
 def _validate_inputs(input_path: Path | str, config: KoffeeConfig) -> None:
@@ -127,6 +349,14 @@ def _validate_api_key(config: KoffeeConfig) -> None:
         raise MissingApiKeyError(error_message)
 
 
+def _validate_file(input_path: Path | str) -> None:
+    """Raises InvalidVideoFileError if the file does not exist or is not a file."""
+    if not Path(input_path).exists() or not Path(input_path).is_file():
+        error_message = "Input file is not valid or does not exist."
+        log.error(error_message)
+        raise InvalidVideoFileError(error_message)
+
+
 def _validate_output_path(input_path: Path | str, config: KoffeeConfig) -> None:
     """Ensures the resolved output path is writable and not already occupied."""
     input_suffix = Path(input_path).suffix.lower()
@@ -143,233 +373,3 @@ def _validate_output_path(input_path: Path | str, config: KoffeeConfig) -> None:
     )
 
     _check_output_collision(output_path, config.overwrite)
-
-
-def _apply_config_overrides(config: KoffeeConfig | None, kwargs: dict) -> KoffeeConfig:
-    """Resolves config, applying any kwarg overrides on top of an existing config."""
-    if config is None:
-        config = KoffeeConfig(**kwargs)
-    else:
-        config = KoffeeConfig(**{**config.model_dump(), **kwargs})
-
-    return config
-
-
-def _transcribe(
-    input_path: Path | str,
-    config: KoffeeConfig,
-    on_progress: Callable[[float], None] | None,
-) -> Transcript:
-    """Transcribes audio from the file, returning the raw transcript."""
-    transcript = transcribe(
-        str(input_path),
-        config.compute_type,
-        config.device,
-        config.whisper_model,
-        config.provider,
-        on_progress=on_progress,
-        vad_filter=config.vad_filter,
-    )
-
-    return transcript
-
-
-def _translate(
-    transcript: Transcript,
-    config: KoffeeConfig,
-    on_progress: Callable[[float], None] | None,
-) -> Path:
-    """Translates transcript segments and writes the subtitle file."""
-    segments = _get_segments(transcript, config, on_progress=on_progress)
-    subtitle_path = generate_subtitles(config.subtitle_format, segments)
-
-    return subtitle_path
-
-
-def _check_output_collision(output_path: Path, overwrite: bool) -> None:
-    """Raises FileExistsError if the output file exists and overwrite is disabled."""
-    if output_path.exists() and not overwrite:
-        error_message = (
-            f"Output file already exists: {output_path}. Use --overwrite to replace it."
-        )
-        raise FileExistsError(error_message)
-
-
-def _route_output(
-    input_path: Path | str,
-    subtitle_path: Path,
-    config: KoffeeConfig,
-) -> Path:
-    """Routes to subtitle output or video embed based on file type and config."""
-    is_audio = Path(input_path).suffix.lower() in AUDIO_EXTENSIONS
-    has_embed = not is_audio and config.embed != "none"
-
-    output_path = _get_output_path(
-        input_path, config.output_dir, config.output_name, date_suffix=has_embed
-    )
-
-    if has_embed:
-        _check_output_collision(output_path, config.overwrite)
-        result_path = _finalize_video_output(
-            subtitle_path,
-            input_path,
-            output_path,
-            config.embed,
-            config.target_language,
-        )
-    else:
-        result_path = _write_output(
-            subtitle_path,
-            input_path,
-            config.subtitle_format,
-            config.output_dir,
-            config.output_name,
-            config.overwrite,
-        )
-
-    return result_path
-
-
-def _translate_embedded_subtitles(
-    input_path: Path | str,
-    config: KoffeeConfig,
-    on_progress: Callable[[float], None] | None,
-) -> Path:
-    """Extracts embedded subtitles from a video and translates them."""
-    log.info("Extracting embedded subtitles from video.")
-
-    extracted_path = extract_subtitle_track(input_path, config.subtitle_track_index)
-    try:
-        result = _translate_subtitle_file(extracted_path, config, on_progress)
-    finally:
-        extracted_path.unlink(missing_ok=True)
-
-    return result
-
-
-def _translate_subtitle_file(
-    file_path: Path | str,
-    config: KoffeeConfig,
-    on_progress: Callable[[float], None] | None,
-) -> Path:
-    """Translates an existing subtitle file without ASR."""
-    log.info("Detected subtitle file input, skipping transcription.")
-
-    segments = parse_subtitle_file(file_path)
-    translated_segments = translate(
-        {"segments": segments, "language": config.source_language},
-        config.target_language,
-        config.api_key,
-        on_progress,
-        llm_model=config.llm_model,
-        prompt=config.prompt,
-        provider=config.provider,
-        sleep_requests=config.sleep_requests,
-    )
-    translated_path = generate_subtitles(config.subtitle_format, translated_segments)
-    output_subtitle_path = _write_output(
-        translated_path,
-        file_path,
-        config.subtitle_format,
-        config.output_dir,
-        config.output_name,
-        config.overwrite,
-    )
-
-    return output_subtitle_path
-
-
-def _get_output_path(
-    input_path: Path | str,
-    output_dir: Path | None,
-    output_name: str | None,
-    date_suffix: bool = False,
-) -> Path:
-    """Gets the output path for the translated output file."""
-    log.debug(f"output_name: {output_name!r}")
-
-    file_path = Path(input_path)
-    file_dir = output_dir if output_dir is not None else file_path.parent
-    file_dir.mkdir(parents=True, exist_ok=True)
-
-    if output_name is not None:
-        file_name = output_name
-    elif date_suffix:
-        file_name = f"{file_path.stem}_{datetime.now().strftime('%m-%d-%Y')}"
-    else:
-        file_name = file_path.stem
-
-    output_path = file_dir / (file_name + file_path.suffix)
-    log.debug(f"output_dir: {output_path!r}")
-
-    return output_path
-
-
-def _get_segments(
-    transcript: Transcript,
-    config: KoffeeConfig,
-    on_progress: Callable[[float], None] | None = None,
-) -> list[Segment]:
-    """Returns translated or raw segments based on the translation backend."""
-    if config.provider == "whisper":
-        segments = transcript["segments"]
-    else:
-        segments = translate(
-            transcript,
-            config.target_language,
-            config.api_key,
-            on_progress,
-            llm_model=config.llm_model,
-            prompt=config.prompt,
-            provider=config.provider,
-            chunk_size=config.chunk_size,
-            context_size=config.context_size,
-            sleep_requests=config.sleep_requests,
-        )
-
-    return segments
-
-
-def _finalize_video_output(
-    subtitle_path: Path,
-    input_path: Path,
-    output_path: Path,
-    embed_mode: str = "soft",
-    language: str = "en",
-) -> Path:
-    """Embeds subtitles into the video and deletes the subtitle file after."""
-    output_video = embed_subtitles(
-        subtitle_path,
-        input_path,
-        output_path,
-        mode=embed_mode,
-        language=language,
-    )
-    subtitle_path.unlink()
-    log.info("Finished processing video!")
-
-    return output_video
-
-
-def _write_output(
-    source_path: Path,
-    input_path: Path | str,
-    subtitle_format: str,
-    output_dir: Path | None,
-    output_name: str | None,
-    overwrite: bool,
-) -> Path:
-    """Moves a generated subtitle file to its resolved output location."""
-    base_path = _get_output_path(input_path, output_dir, output_name)
-    target_path = base_path.with_suffix(f".{subtitle_format}")
-
-    try:
-        _check_output_collision(target_path, overwrite)
-    except FileExistsError:
-        source_path.unlink(missing_ok=True)
-        raise
-
-    source_path.replace(target_path)
-    log.info("Finished processing file!")
-
-    return target_path

--- a/koffee/asr.py
+++ b/koffee/asr.py
@@ -35,6 +35,23 @@ def transcribe(
     return transcript
 
 
+def _consume_segments(
+    segments, video_file: str, on_progress: Callable[[float], None] | None
+) -> list[Segment]:
+    """Consumes the segment generator, reporting progress as each segment is yielded."""
+    duration = get_video_duration(video_file) if on_progress else None
+    result = []
+    for segment in segments:
+        result.append(asdict(segment))
+        if on_progress and duration:
+            on_progress(min(segment.end / duration, 1.0))
+
+    if on_progress:
+        on_progress(1.0)
+
+    return result
+
+
 def _load_model(compute_type: str, device: str, model: str) -> WhisperModel:
     """Loads and returns a Whisper model with the given configuration."""
     loaded_model = WhisperModel(
@@ -57,20 +74,3 @@ def _run_transcription(
     )
 
     return segments, info
-
-
-def _consume_segments(
-    segments, video_file: str, on_progress: Callable[[float], None] | None
-) -> list[Segment]:
-    """Consumes the segment generator, reporting progress as each segment is yielded."""
-    duration = get_video_duration(video_file) if on_progress else None
-    result = []
-    for segment in segments:
-        result.append(asdict(segment))
-        if on_progress and duration:
-            on_progress(min(segment.end / duration, 1.0))
-
-    if on_progress:
-        on_progress(1.0)
-
-    return result

--- a/koffee/cli/embedded.py
+++ b/koffee/cli/embedded.py
@@ -31,20 +31,6 @@ def _apply_subtitle_track(config: KoffeeConfig, tracks: list[dict]) -> KoffeeCon
     return config.model_copy(update=updates)
 
 
-def _detect_embedded_subtitles(video_path: Path) -> list[dict]:
-    """Returns embedded subtitle tracks in the video, or an empty list."""
-    if video_path.suffix.lower() in SUBTITLE_EXTENSIONS:
-        return []
-
-    return get_subtitle_tracks(video_path)
-
-
-def _prompt_use_embedded_subtitles() -> bool:
-    """Prompts the user to use embedded subtitles instead of running ASR."""
-    user_input = input("Translate embedded subtitles instead of running ASR? [Y/n] ")
-    return user_input.strip().lower() in ("", "y", "yes")
-
-
 def _select_subtitle_track(tracks: list[dict]) -> tuple[int, str | None]:
     """Prompts user to select a subtitle track if multiple are available."""
     if len(tracks) == 1:
@@ -67,3 +53,17 @@ def _select_subtitle_track(tracks: list[dict]) -> tuple[int, str | None]:
 
     language = tracks[index].get("tags", {}).get("language")
     return index, language
+
+
+def _detect_embedded_subtitles(video_path: Path) -> list[dict]:
+    """Returns embedded subtitle tracks in the video, or an empty list."""
+    if video_path.suffix.lower() in SUBTITLE_EXTENSIONS:
+        return []
+
+    return get_subtitle_tracks(video_path)
+
+
+def _prompt_use_embedded_subtitles() -> bool:
+    """Prompts the user to use embedded subtitles instead of running ASR."""
+    user_input = input("Translate embedded subtitles instead of running ASR? [Y/n] ")
+    return user_input.strip().lower() in ("", "y", "yes")

--- a/koffee/embed.py
+++ b/koffee/embed.py
@@ -12,13 +12,6 @@ log = logging.getLogger(__name__)
 MKV_EXTENSIONS = {".mkv", ".webm"}
 
 
-def _get_subtitle_codec(output_path: Path | str) -> str:
-    """Returns the appropriate subtitle codec for the output container."""
-    if Path(output_path).suffix.lower() in MKV_EXTENSIONS:
-        return "srt"
-    return "mov_text"
-
-
 def embed_subtitles(
     subtitle_path: Path | str,
     video_path: Path | str,
@@ -38,6 +31,50 @@ def embed_subtitles(
     if mode == "hard":
         return _burn_in_subtitles(subtitle_path, video_path, output_path)
     return _mux_subtitles(subtitle_path, video_path, output_path, language)
+
+
+def _burn_in_subtitles(
+    subtitle_path: Path | str,
+    video_path: Path | str,
+    output_path: Path | str,
+) -> Path | str:
+    """Burns subtitles into the video frames (hard subtitles)."""
+    log.info("Burning in subtitles (hard).")
+
+    escaped_path = _escape_subtitle_filter_path(subtitle_path)
+
+    cmd = [
+        "ffmpeg",
+        "-i",
+        str(video_path),
+        "-vf",
+        f"subtitles={escaped_path}",
+        "-c:a",
+        "copy",
+        "-y",
+        str(output_path),
+    ]
+
+    try:
+        subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=600)
+    except FileNotFoundError:
+        log.error("ffmpeg not found. Please install ffmpeg to use this feature.")
+        raise
+    except subprocess.TimeoutExpired:
+        log.error("ffmpeg timed out while burning in subtitles.")
+        raise
+    except subprocess.CalledProcessError as error:
+        raise SubtitleEmbedError(error.stderr) from error
+
+    return output_path
+
+
+def _escape_subtitle_filter_path(subtitle_path: Path | str) -> str:
+    """Escapes a path for use in the ffmpeg `subtitles=` filter argument."""
+    path = str(subtitle_path).replace("\\", "/")
+    for char in (":", "'", "[", "]", ",", ";"):
+        path = path.replace(char, f"\\{char}")
+    return path
 
 
 def _mux_subtitles(
@@ -81,45 +118,8 @@ def _mux_subtitles(
     return output_path
 
 
-def _escape_subtitle_filter_path(subtitle_path: Path | str) -> str:
-    """Escapes a path for use in the ffmpeg `subtitles=` filter argument."""
-    path = str(subtitle_path).replace("\\", "/")
-    for char in (":", "'", "[", "]", ",", ";"):
-        path = path.replace(char, f"\\{char}")
-    return path
-
-
-def _burn_in_subtitles(
-    subtitle_path: Path | str,
-    video_path: Path | str,
-    output_path: Path | str,
-) -> Path | str:
-    """Burns subtitles into the video frames (hard subtitles)."""
-    log.info("Burning in subtitles (hard).")
-
-    escaped_path = _escape_subtitle_filter_path(subtitle_path)
-
-    cmd = [
-        "ffmpeg",
-        "-i",
-        str(video_path),
-        "-vf",
-        f"subtitles={escaped_path}",
-        "-c:a",
-        "copy",
-        "-y",
-        str(output_path),
-    ]
-
-    try:
-        subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=600)
-    except FileNotFoundError:
-        log.error("ffmpeg not found. Please install ffmpeg to use this feature.")
-        raise
-    except subprocess.TimeoutExpired:
-        log.error("ffmpeg timed out while burning in subtitles.")
-        raise
-    except subprocess.CalledProcessError as error:
-        raise SubtitleEmbedError(error.stderr) from error
-
-    return output_path
+def _get_subtitle_codec(output_path: Path | str) -> str:
+    """Returns the appropriate subtitle codec for the output container."""
+    if Path(output_path).suffix.lower() in MKV_EXTENSIONS:
+        return "srt"
+    return "mov_text"

--- a/koffee/llm/chatgpt.py
+++ b/koffee/llm/chatgpt.py
@@ -11,11 +11,6 @@ def create_client(api_key: str | None):
     return OpenAI(api_key=api_key)
 
 
-def extract_text(response) -> str:
-    """Extracts the generated text from a ChatGPT response."""
-    return response.choices[0].message.content
-
-
 def attempt_generate(client, prompt: str, model: str, system_prompt: str):
     """Makes a single OpenAI API call, returning the response."""
     return client.chat.completions.create(
@@ -25,6 +20,11 @@ def attempt_generate(client, prompt: str, model: str, system_prompt: str):
             {"role": "user", "content": prompt},
         ],
     )
+
+
+def extract_text(response) -> str:
+    """Extracts the generated text from a ChatGPT response."""
+    return response.choices[0].message.content
 
 
 def is_retryable(exc: Exception) -> bool:

--- a/koffee/llm/claude.py
+++ b/koffee/llm/claude.py
@@ -11,11 +11,6 @@ def create_client(api_key: str | None):
     return Anthropic(api_key=api_key)
 
 
-def extract_text(response) -> str:
-    """Extracts the generated text from a Claude response."""
-    return response.content[0].text
-
-
 def attempt_generate(client, prompt: str, model: str, system_prompt: str):
     """Makes a single Claude API call, returning the response."""
     return client.messages.create(
@@ -24,6 +19,11 @@ def attempt_generate(client, prompt: str, model: str, system_prompt: str):
         system=system_prompt,
         messages=[{"role": "user", "content": prompt}],
     )
+
+
+def extract_text(response) -> str:
+    """Extracts the generated text from a Claude response."""
+    return response.content[0].text
 
 
 def is_retryable(exc: Exception) -> bool:

--- a/koffee/llm/gemini.py
+++ b/koffee/llm/gemini.py
@@ -16,11 +16,6 @@ def create_client(api_key: str | None):
     return genai.Client(api_key=api_key)
 
 
-def extract_text(response) -> str:
-    """Extracts the generated text from a Gemini response."""
-    return response.text
-
-
 def attempt_generate(client, prompt: str, model: str, system_prompt: str):
     """Makes a single Gemini API call, returning the response."""
     response = client.models.generate_content(
@@ -39,6 +34,11 @@ def attempt_generate(client, prompt: str, model: str, system_prompt: str):
     )
     log.debug(f"Gemini response tail:\n{response.text[-500:]}")
     return response
+
+
+def extract_text(response) -> str:
+    """Extracts the generated text from a Gemini response."""
+    return response.text
 
 
 def is_retryable(exc: Exception) -> bool:

--- a/koffee/llm/ollama.py
+++ b/koffee/llm/ollama.py
@@ -13,11 +13,6 @@ def create_client(api_key: str | None):
     return OpenAI(base_url=OLLAMA_BASE_URL, api_key="ollama")
 
 
-def extract_text(response) -> str:
-    """Extracts the generated text from an Ollama response."""
-    return response.choices[0].message.content
-
-
 def attempt_generate(client, prompt: str, model: str, system_prompt: str):
     """Makes a single Ollama API call, returning the response."""
     return client.chat.completions.create(
@@ -27,6 +22,11 @@ def attempt_generate(client, prompt: str, model: str, system_prompt: str):
             {"role": "user", "content": prompt},
         ],
     )
+
+
+def extract_text(response) -> str:
+    """Extracts the generated text from an Ollama response."""
+    return response.choices[0].message.content
 
 
 def is_retryable(exc: Exception) -> bool:

--- a/koffee/translator.py
+++ b/koffee/translator.py
@@ -106,21 +106,6 @@ def translate(
     return translated_segments
 
 
-def _load_backend(backend_name: str) -> TranslationProvider:
-    """Loads a translation backend module by name."""
-    import importlib  # noqa: PLC0415
-
-    module_path = LLM.get(backend_name)
-    if module_path is None:
-        available = ", ".join(sorted(LLM.keys()))
-        error_message = (
-            f"Unknown translation backend: {backend_name!r}. Available LLM: {available}"
-        )
-        raise ValueError(error_message)
-
-    return importlib.import_module(module_path)
-
-
 def _chunk_segments(
     transcript: Transcript, target_language: str, chunk_size: int = CHUNK_SIZE
 ) -> list[Chunk]:
@@ -139,6 +124,21 @@ def _chunk_segments(
     ]
 
     return chunks
+
+
+def _load_backend(backend_name: str) -> TranslationProvider:
+    """Loads a translation backend module by name."""
+    import importlib  # noqa: PLC0415
+
+    module_path = LLM.get(backend_name)
+    if module_path is None:
+        available = ", ".join(sorted(LLM.keys()))
+        error_message = (
+            f"Unknown translation backend: {backend_name!r}. Available LLM: {available}"
+        )
+        raise ValueError(error_message)
+
+    return importlib.import_module(module_path)
 
 
 def _translate_chunks(
@@ -179,6 +179,55 @@ def _translate_chunks(
     return translated_segments
 
 
+def _build_prompt(
+    chunk: list[Segment],
+    context_segments: list[Segment],
+    source_language: str,
+    target_language: str,
+    start_entry: int,
+) -> str:
+    """Builds the translation prompt for a chunk of subtitle entries."""
+    if source_language == "auto":
+        instruction = f"Translate the following subtitle entries to {target_language}."
+    else:
+        instruction = (
+            f"Translate the following subtitle entries from "
+            f"{source_language} to {target_language}."
+        )
+
+    prompt_parts = [instruction]
+
+    if context_segments:
+        prompt_parts.extend(
+            [
+                f"The following {len(context_segments)} entries are provided as "
+                "context only to maintain narrative continuity. Do not include them "
+                "in your translation."
+                f" output. Begin your translation from entry {start_entry} only.\n",
+                "[CONTEXT - DO NOT TRANSLATE]\n",
+                _segments_to_srt(context_segments),
+                "\n[TRANSLATE FROM HERE]\n",
+            ]
+        )
+
+    prompt_parts.append(_segments_to_srt(chunk))
+    translation_prompt = "\n".join(prompt_parts)
+
+    return translation_prompt
+
+
+def _segments_to_srt(segments: list[Segment]) -> str:
+    """Converts a list of segments to SRT format string."""
+    lines = []
+    for i, seg in enumerate(segments, 1):
+        start = convert_to_timestamp(seg["start"], "srt")
+        end = convert_to_timestamp(seg["end"], "srt")
+        lines.append(f"{i}\n{start} --> {end}\n{seg['text'].strip()}\n")
+
+    srt_text = "\n".join(lines)
+    return srt_text
+
+
 def _translate_chunk(
     backend: ModuleType,
     client,
@@ -209,43 +258,6 @@ def _call_with_retries(
         backend.is_retryable,
         max_retries=max_retries,
     )
-
-
-def _segments_to_srt(segments: list[Segment]) -> str:
-    """Converts a list of segments to SRT format string."""
-    lines = []
-    for i, seg in enumerate(segments, 1):
-        start = convert_to_timestamp(seg["start"], "srt")
-        end = convert_to_timestamp(seg["end"], "srt")
-        lines.append(f"{i}\n{start} --> {end}\n{seg['text'].strip()}\n")
-
-    srt_text = "\n".join(lines)
-    return srt_text
-
-
-def _sanitize_response(response_text: str | None) -> str:
-    """Strips thinking blocks, markdown fences, and normalizes line endings."""
-    if not response_text:
-        return ""
-
-    text = response_text.replace("\r\n", "\n").strip()
-
-    if "<think>" in text:
-        end = text.find("</think>")
-        if end != -1:
-            text = text[end + len("</think>") :].strip()
-        else:
-            text = text[text.find("<think>") + len("<think>") :].strip()
-
-    if text.startswith("```"):
-        first_newline = text.find("\n")
-        if first_newline != -1:
-            text = text[first_newline + 1 :]
-        if text.endswith("```"):
-            text = text[:-3]
-        text = text.strip()
-
-    return text
 
 
 def _parse_srt_response(
@@ -310,38 +322,26 @@ def _merge_translated_segments(
     return merged_segments
 
 
-def _build_prompt(
-    chunk: list[Segment],
-    context_segments: list[Segment],
-    source_language: str,
-    target_language: str,
-    start_entry: int,
-) -> str:
-    """Builds the translation prompt for a chunk of subtitle entries."""
-    if source_language == "auto":
-        instruction = f"Translate the following subtitle entries to {target_language}."
-    else:
-        instruction = (
-            f"Translate the following subtitle entries from "
-            f"{source_language} to {target_language}."
-        )
+def _sanitize_response(response_text: str | None) -> str:
+    """Strips thinking blocks, markdown fences, and normalizes line endings."""
+    if not response_text:
+        return ""
 
-    prompt_parts = [instruction]
+    text = response_text.replace("\r\n", "\n").strip()
 
-    if context_segments:
-        prompt_parts.extend(
-            [
-                f"The following {len(context_segments)} entries are provided as "
-                "context only to maintain narrative continuity. Do not include them "
-                "in your translation."
-                f" output. Begin your translation from entry {start_entry} only.\n",
-                "[CONTEXT - DO NOT TRANSLATE]\n",
-                _segments_to_srt(context_segments),
-                "\n[TRANSLATE FROM HERE]\n",
-            ]
-        )
+    if "<think>" in text:
+        end = text.find("</think>")
+        if end != -1:
+            text = text[end + len("</think>") :].strip()
+        else:
+            text = text[text.find("<think>") + len("<think>") :].strip()
 
-    prompt_parts.append(_segments_to_srt(chunk))
-    translation_prompt = "\n".join(prompt_parts)
+    if text.startswith("```"):
+        first_newline = text.find("\n")
+        if first_newline != -1:
+            text = text[first_newline + 1 :]
+        if text.endswith("```"):
+            text = text[:-3]
+        text = text.strip()
 
-    return translation_prompt
+    return text

--- a/koffee/utils/subtitle_extractor.py
+++ b/koffee/utils/subtitle_extractor.py
@@ -8,38 +8,6 @@ from pathlib import Path
 log = logging.getLogger(__name__)
 
 
-def get_subtitle_tracks(video_path: Path | str) -> list[dict]:
-    """Returns a list of subtitle track metadata from a video file."""
-    try:
-        result = subprocess.run(
-            [
-                "ffprobe",
-                "-v",
-                "error",
-                "-select_streams",
-                "s",
-                "-show_entries",
-                "stream=index:stream_tags=language,title",
-                "-of",
-                "json",
-                str(video_path),
-            ],
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=30,
-        )
-    except FileNotFoundError:
-        log.error("ffprobe not found. Please install ffmpeg to use this feature.")
-        raise
-    except subprocess.TimeoutExpired:
-        log.error("ffprobe timed out while reading subtitle tracks.")
-        raise
-
-    data = json.loads(result.stdout)
-    return data.get("streams", [])
-
-
 def extract_subtitle_track(video_path: Path | str, track_index: int = 0) -> Path:
     """Extracts a subtitle track from a video file to a temporary SRT file."""
     output_path = Path(video_path).parent / f".koffee_extracted_{track_index}.srt"
@@ -73,3 +41,35 @@ def extract_subtitle_track(video_path: Path | str, track_index: int = 0) -> Path
         raise
 
     return output_path
+
+
+def get_subtitle_tracks(video_path: Path | str) -> list[dict]:
+    """Returns a list of subtitle track metadata from a video file."""
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-select_streams",
+                "s",
+                "-show_entries",
+                "stream=index:stream_tags=language,title",
+                "-of",
+                "json",
+                str(video_path),
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        )
+    except FileNotFoundError:
+        log.error("ffprobe not found. Please install ffmpeg to use this feature.")
+        raise
+    except subprocess.TimeoutExpired:
+        log.error("ffprobe timed out while reading subtitle tracks.")
+        raise
+
+    data = json.loads(result.stdout)
+    return data.get("streams", [])

--- a/koffee/utils/subtitle_parser.py
+++ b/koffee/utils/subtitle_parser.py
@@ -55,6 +55,15 @@ def parse_subtitle_file(file_path: Path | str) -> list[Segment]:
     return segments
 
 
+def _find_timestamp_line(lines: list[str]) -> tuple[int, str, str] | None:
+    """Finds the timestamp line in a block and returns (index, start, end)."""
+    for i, line in enumerate(lines):
+        match = TIMESTAMP_PATTERN.search(line)
+        if match:
+            return i, match.group(1), match.group(2)
+    return None
+
+
 def _parse_ass(text: str, file_path: Path) -> list[Segment]:
     """Parses ASS/SSA formatted text into segment dicts."""
     segments = []
@@ -85,15 +94,6 @@ def _ass_timestamp_to_seconds(timestamp: str) -> float:
     return (
         int(hours) * 3600 + int(minutes) * 60 + int(seconds) + int(centiseconds) / 100
     )
-
-
-def _find_timestamp_line(lines: list[str]) -> tuple[int, str, str] | None:
-    """Finds the timestamp line in a block and returns (index, start, end)."""
-    for i, line in enumerate(lines):
-        match = TIMESTAMP_PATTERN.search(line)
-        if match:
-            return i, match.group(1), match.group(2)
-    return None
 
 
 def _timestamp_to_seconds(timestamp: str) -> float:


### PR DESCRIPTION
## Summary
Applies a consistent function-ordering convention across ten modules. Pure reordering, no behavior changes.

## Convention
- Public orchestrator first.
- Private helpers follow in depth-first call order, so caller sits above callee and each function's local scope reads as a contiguous block.
- Shared helpers (called by multiple functions) sit under their first caller, not hoisted below every caller. This is a loose Clean Code stepdown rather than a strict topological sort; a later caller may sit below a helper it uses, which is accepted in exchange for locality.
- Peer functions with no caller/callee relationship order by:
  1. Protocol/ABC declaration order, where one exists (e.g. `koffee/llm/*.py` implementing `TranslationProvider`).
  2. Alphabetical, otherwise.