### PR TITLE
Offer to save transcription as subtitles on translation failure

### DIFF
--- a/koffee/api.py
+++ b/koffee/api.py
@@ -14,6 +14,7 @@ from koffee.exceptions import (
     InvalidVideoFileError,
     MissingApiKeyError,
     MissingDependencyError,
+    TranslationError,
     UnsupportedFileError,
 )
 from koffee.schemas.config import KoffeeConfig
@@ -54,7 +55,10 @@ def run(
         return _translate_embedded_subtitles(input_path, config, on_translate_progress)
 
     transcript = _transcribe(input_path, config, on_asr_progress)
-    subtitle_path = _translate(transcript, config, on_translate_progress)
+    try:
+        subtitle_path = _translate(transcript, config, on_translate_progress)
+    except Exception as exc:
+        raise TranslationError(str(exc), transcript["segments"]) from exc
     output_path = _route_output(input_path, subtitle_path, config)
 
     return output_path

--- a/koffee/cli/commands.py
+++ b/koffee/cli/commands.py
@@ -17,7 +17,7 @@ from koffee.cli.app import app, defaults, log, options_group
 from koffee.cli.embedded import _handle_embedded_subtitles
 from koffee.cli.progress import _create_progress_bar, _make_progress_callback
 from koffee.embed import embed_subtitles
-from koffee.exceptions import KoffeeError
+from koffee.exceptions import KoffeeError, TranslationError
 from koffee.schemas.config import (
     CONFIG_SEARCH_PATHS,
     LANGUAGE_CODES,
@@ -264,12 +264,32 @@ def _translate_with_progress(
                     progress.update(translate_task, visible=True)
                     progress.start_task(translate_task)
 
-        run(
-            input_path=video_path,
-            config=config,
-            on_asr_progress=on_asr_progress,
-            on_translate_progress=translate_callback,
-        )
+        try:
+            run(
+                input_path=video_path,
+                config=config,
+                on_asr_progress=on_asr_progress,
+                on_translate_progress=translate_callback,
+            )
+        except TranslationError as exc:
+            log.error(f"Translation failed: {exc}")
+            answer = input("Save transcription as subtitles for manual retry? [y/N] ")
+            if answer.strip().lower() == "y":
+                raw_path = generate_subtitles(config.subtitle_format, exc.segments)
+                output_path = _write_output(
+                    raw_path,
+                    video_path,
+                    config.subtitle_format,
+                    config.output_dir,
+                    config.output_name,
+                    config.overwrite,
+                )
+                log.info(
+                    f"Transcription saved to {output_path}. "
+                    f"Retry: koffee {output_path} --provider=<provider>"
+                )
+            else:
+                raise
 
 
 @app.command()

--- a/koffee/exceptions.py
+++ b/koffee/exceptions.py
@@ -29,5 +29,14 @@ class SubtitleEmbedError(KoffeeError):
     """Subtitle embedding not possible for the given file."""
 
 
+class TranslationError(KoffeeError):
+    """Translation step failed after successful transcription."""
+
+    def __init__(self, message: str, segments: list) -> None:
+        """Stores the raw transcript segments alongside the error."""
+        super().__init__(message)
+        self.segments = segments
+
+
 class UnsupportedFileError(KoffeeError):
     """Input file has an unsupported extension."""


### PR DESCRIPTION
If translation fails after a successful transcription, koffee now prompts the user to save the raw transcription as a subtitle file. They can then rerun with the subtitle file as input to retry translation without repeating the Whisper step.

Three files changed:

- `exceptions.py`: new `TranslationError` carrying the raw segments
- `api.py`: wraps `_translate()` to raise `TranslationError` on failure
- `commands.py`: catches `TranslationError`, prompts, and writes the subtitle file if confirmed