### PR TITLE
Fix transcribe subcommand running whisper in translate-to-English mode

### DIFF
--- a/koffee/api.py
+++ b/koffee/api.py
@@ -195,12 +195,13 @@ def _transcribe(
     on_progress: Callable[[float], None] | None,
 ) -> Transcript:
     """Transcribes audio from the file, returning the raw transcript."""
+    task = "translate" if config.provider == "whisper" else "transcribe"
     transcript = transcribe(
         str(input_path),
         config.compute_type,
         config.device,
         config.whisper_model,
-        config.provider,
+        task,
         on_progress=on_progress,
         vad_filter=config.vad_filter,
     )

--- a/koffee/asr.py
+++ b/koffee/asr.py
@@ -18,7 +18,7 @@ def transcribe(
     compute_type: str,
     device: str,
     model: str,
-    provider: str,
+    task: str,
     on_progress: Callable[[float], None] | None = None,
     vad_filter: bool = True,
 ) -> Transcript:
@@ -26,7 +26,7 @@ def transcribe(
     log.info("Transcribing file.")
 
     loaded_model = _load_model(compute_type, device, model)
-    segments, info = _run_transcription(loaded_model, video_file, provider, vad_filter)
+    segments, info = _run_transcription(loaded_model, video_file, task, vad_filter)
 
     transcript = {
         "segments": _consume_segments(segments, video_file, on_progress),
@@ -66,10 +66,9 @@ def _load_model(compute_type: str, device: str, model: str) -> WhisperModel:
 
 
 def _run_transcription(
-    loaded_model: WhisperModel, video_file: str, provider: str, vad_filter: bool
+    loaded_model: WhisperModel, video_file: str, task: str, vad_filter: bool
 ) -> tuple:
     """Runs transcription on the video file, returning segments and info."""
-    task = "translate" if provider == "whisper" else "transcribe"
     segments, info = loaded_model.transcribe(
         video_file, task=task, word_timestamps=True, vad_filter=vad_filter
     )

--- a/koffee/cli/commands.py
+++ b/koffee/cli/commands.py
@@ -531,7 +531,7 @@ def transcribe(
             compute_type,
             device,
             whisper_model,
-            "whisper",
+            "transcribe",
             on_progress=_make_progress_callback(progress, asr_task),
             vad_filter=vad_filter,
         )

--- a/tests/test_asr.py
+++ b/tests/test_asr.py
@@ -29,11 +29,11 @@ def test_transcribe(mocker: MockerFixture) -> None:
 
     mocker.patch("koffee.asr.WhisperModel", return_value=mock_model)
 
-    result = transcribe("mock_video_file.mp4", "int8", "auto", "large-v3", "whisper")
+    result = transcribe("mock_video_file.mp4", "int8", "auto", "large-v3", "transcribe")
 
     mock_model.transcribe.assert_called_once_with(
         "mock_video_file.mp4",
-        task="translate",
+        task="transcribe",
         word_timestamps=True,
         vad_filter=True,
     )
@@ -61,7 +61,7 @@ def test_transcribe_reports_progress(mocker: MockerFixture) -> None:
         "int8",
         "auto",
         "large-v3",
-        "whisper",
+        "translate",
         on_progress=progress_calls.append,
     )
 


### PR DESCRIPTION
The transcribe subcommand was passing "whisper" as the provider to
asr.transcribe, which then mapped to faster-whisper's task="translate"
and produced English output instead of source-language transcription.

- asr.transcribe now takes task directly instead of provider, removing the
  leaky provider->task mapping
- api.py translates provider into task at the boundary (whisper -> translate,
  anything else -> transcribe), preserving existing default-command behavior
- transcribe subcommand passes task="transcribe", so it now produces
  source-language subtitles as the name implies
- test_asr covers both task values