### PR TITLE
Add --on-translation-failure flag and fix prompt hidden by progress bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Refer below for a list of all arguments, commands, parameters, and options.
     --context-size              Number of preceding entries passed as context per request (auto-selected per model if unset)
     --prompt                    Custom system prompt for the LLM translation model
     --api-key                   API key for an LLM service
+    --on-translation-failure    What to do when LLM translation fails: prompt (default), save, or abort. Non-TTY stdin falls back to save
 
 ### Options
 

--- a/koffee/cli/__init__.py
+++ b/koffee/cli/__init__.py
@@ -3,8 +3,11 @@
 from koffee.cli.app import app
 from koffee.cli.commands import (
     _find_config_path,
+    _handle_translation_failure,
     _print_dry_run,
     _resolve_paths,
+    _run_batch,
+    _save_raw_transcription,
     _translate_with_progress,
     cli,
     convert,
@@ -23,8 +26,11 @@ from koffee.cli.embedded import (
 __all__ = [
     "_find_config_path",
     "_handle_embedded_subtitles",
+    "_handle_translation_failure",
     "_print_dry_run",
     "_resolve_paths",
+    "_run_batch",
+    "_save_raw_transcription",
     "_select_subtitle_track",
     "_translate_with_progress",
     "app",

--- a/koffee/cli/commands.py
+++ b/koffee/cli/commands.py
@@ -57,6 +57,9 @@ def cli(
     sleep_requests: Annotated[int, Parameter(name=("--sleep-requests",))] | None = None,
     prompt: Annotated[str, Parameter(name=("--prompt",))] | None = None,
     api_key: Annotated[str, Parameter(name=("--api-key",))] | None = None,
+    on_translation_failure: Annotated[
+        str, Parameter(name=("--on-translation-failure",))
+    ] = defaults.on_translation_failure,
     config: Annotated[Path, Parameter(name=("--config",), group=options_group)]
     | None = None,
     vad_filter: Annotated[
@@ -107,6 +110,10 @@ def cli(
         Path to a koffee.toml configuration file
     api_key: str
         API key for an LLM service
+    on_translation_failure: str
+        What to do when LLM translation fails: prompt (default; ask y/n to save
+        the raw transcription), save (save without asking), or abort (skip the
+        save). When stdin is not a TTY, prompt falls back to save.
     vad_filter: bool
         Voice activity detection filtering during transcription (enabled by default;
         pass `--no-vad-filter` to disable)
@@ -139,6 +146,7 @@ def cli(
         "target_language": target_language,
         "provider": provider,
         "prompt": prompt,
+        "on_translation_failure": on_translation_failure,
         "vad_filter": vad_filter,
     }
     default_config = KoffeeConfig().model_dump()

--- a/koffee/cli/commands.py
+++ b/koffee/cli/commands.py
@@ -3,6 +3,7 @@
 import logging
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 from typing import Annotated
 
@@ -257,6 +258,10 @@ def _handle_translation_failure(
     log.error(f"Translation failed: {exc}")
 
     decision = config.on_translation_failure
+    if decision == "prompt" and not sys.stdin.isatty():
+        log.info("stdin is not a TTY; saving transcription instead of prompting.")
+        decision = "save"
+
     if decision == "abort":
         return False
 

--- a/koffee/cli/commands.py
+++ b/koffee/cli/commands.py
@@ -164,30 +164,7 @@ def cli(
         _print_dry_run(resolved_paths, config)
         return
 
-    total = len(resolved_paths)
-    failed = []
-    with _create_progress_bar() as progress:
-        for i, video_path in enumerate(resolved_paths, 1):
-            if total > 1:
-                log.info(f"[{i}/{total}] Processing {video_path.name}")
-            try:
-                _translate_with_progress(video_path, config, progress)
-            except (
-                FileExistsError,
-                FileNotFoundError,
-                KoffeeError,
-                subprocess.CalledProcessError,
-                subprocess.TimeoutExpired,
-            ) as exc:
-                log.error(f"Failed to process {video_path.name}: {exc}")
-                failed.append(video_path)
-
-    if total > 1:
-        succeeded = total - len(failed)
-        log.info(f"Batch complete: {succeeded}/{total} succeeded.")
-        if failed:
-            for path in failed:
-                log.info(f"  failed: {path.name}")
+    _run_batch(resolved_paths, config)
 
 
 def _print_dry_run(resolved_paths: list[Path], config: KoffeeConfig) -> None:
@@ -234,6 +211,84 @@ def _resolve_paths(file_path: tuple) -> list[Path]:
     return resolved_paths
 
 
+def _run_batch(resolved_paths: list[Path], config: KoffeeConfig) -> None:
+    """Processes each resolved path, handling failures without aborting the batch."""
+    total = len(resolved_paths)
+    failed = []
+    with _create_progress_bar() as progress:
+        for i, video_path in enumerate(resolved_paths, 1):
+            if total > 1:
+                log.info(f"[{i}/{total}] Processing {video_path.name}")
+            try:
+                _translate_with_progress(video_path, config, progress)
+            except TranslationError as exc:
+                if not _handle_translation_failure(exc, video_path, config, progress):
+                    failed.append(video_path)
+            except (
+                FileExistsError,
+                FileNotFoundError,
+                KoffeeError,
+                subprocess.CalledProcessError,
+                subprocess.TimeoutExpired,
+            ) as exc:
+                log.error(f"Failed to process {video_path.name}: {exc}")
+                failed.append(video_path)
+
+    if total > 1:
+        succeeded = total - len(failed)
+        log.info(f"Batch complete: {succeeded}/{total} succeeded.")
+        if failed:
+            for path in failed:
+                log.info(f"  failed: {path.name}")
+
+
+def _handle_translation_failure(
+    exc: TranslationError,
+    video_path: Path,
+    config: KoffeeConfig,
+    progress: Progress,
+) -> bool:
+    """Decides whether to save the raw transcription after a translation failure.
+
+    Returns True if the failure was handled (saved or explicitly skipped) so the
+    batch can continue cleanly; returns False to mark the file as failed.
+    """
+    log.error(f"Translation failed: {exc}")
+
+    decision = config.on_translation_failure
+    if decision == "abort":
+        return False
+
+    if decision == "prompt":
+        answer = input("Save transcription as subtitles for manual retry? [y/N] ")
+        if answer.strip().lower() != "y":
+            return False
+
+    _save_raw_transcription(exc, video_path, config)
+    return True
+
+
+def _save_raw_transcription(
+    exc: TranslationError,
+    video_path: Path,
+    config: KoffeeConfig,
+) -> None:
+    """Writes the raw (untranslated) transcript to disk for manual retry."""
+    raw_path = generate_subtitles(config.subtitle_format, exc.segments)
+    output_path = _write_output(
+        raw_path,
+        video_path,
+        config.subtitle_format,
+        config.output_dir,
+        config.output_name,
+        config.overwrite,
+    )
+    log.info(
+        f"Transcription saved to {output_path}. "
+        f"Retry: koffee {output_path} --provider=<provider>"
+    )
+
+
 def _translate_with_progress(
     video_path: Path,
     config: KoffeeConfig,
@@ -272,32 +327,12 @@ def _translate_with_progress(
                     progress.update(translate_task, visible=True)
                     progress.start_task(translate_task)
 
-        try:
-            run(
-                input_path=video_path,
-                config=config,
-                on_asr_progress=on_asr_progress,
-                on_translate_progress=translate_callback,
-            )
-        except TranslationError as exc:
-            log.error(f"Translation failed: {exc}")
-            answer = input("Save transcription as subtitles for manual retry? [y/N] ")
-            if answer.strip().lower() == "y":
-                raw_path = generate_subtitles(config.subtitle_format, exc.segments)
-                output_path = _write_output(
-                    raw_path,
-                    video_path,
-                    config.subtitle_format,
-                    config.output_dir,
-                    config.output_name,
-                    config.overwrite,
-                )
-                log.info(
-                    f"Transcription saved to {output_path}. "
-                    f"Retry: koffee {output_path} --provider=<provider>"
-                )
-            else:
-                raise
+        run(
+            input_path=video_path,
+            config=config,
+            on_asr_progress=on_asr_progress,
+            on_translate_progress=translate_callback,
+        )
 
 
 @app.command()

--- a/koffee/cli/commands.py
+++ b/koffee/cli/commands.py
@@ -9,6 +9,7 @@ from typing import Annotated
 from cyclopts import Parameter, validators
 from rich.console import Console
 from rich.progress import Progress
+from rich.prompt import Confirm
 from rich.table import Table
 
 from koffee import asr
@@ -260,8 +261,12 @@ def _handle_translation_failure(
         return False
 
     if decision == "prompt":
-        answer = input("Save transcription as subtitles for manual retry? [y/N] ")
-        if answer.strip().lower() != "y":
+        save = Confirm.ask(
+            "Save transcription as subtitles for manual retry?",
+            default=False,
+            console=progress.console,
+        )
+        if not save:
             return False
 
     _save_raw_transcription(exc, video_path, config)

--- a/koffee/schemas/config.py
+++ b/koffee/schemas/config.py
@@ -150,6 +150,7 @@ class KoffeeConfig(BaseModel):
     vad_filter: bool = True
     subtitle_track_index: int = 0
     use_embedded_subtitles: bool = False
+    on_translation_failure: Literal["prompt", "save", "abort"] = "prompt"
 
     @model_validator(mode="before")
     @classmethod

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,7 +21,7 @@ from koffee.cli import (
     tracks,
     transcribe,
 )
-from koffee.exceptions import KoffeeError
+from koffee.exceptions import KoffeeError, TranslationError
 from koffee.schemas.config import LANGUAGE_CODES, KoffeeConfig
 
 korean_video_path = Path("examples/videos/sample_korean_video.mp4")
@@ -308,6 +308,115 @@ def test_batch_summary_on_partial_failure(mocker: MockerFixture) -> None:
     assert any("1/2 succeeded" in msg for msg in info_messages)
     assert any("failed" in msg for msg in info_messages)
     assert any("boom" in msg for msg in error_messages)
+
+
+def test_translation_failure_prompt_yes_saves(mocker: MockerFixture) -> None:
+    """Tests that answering yes at the prompt triggers a transcription save."""
+    mocker.patch(
+        "koffee.cli.commands.run", side_effect=TranslationError("boom", segments=[])
+    )
+    mocker.patch("koffee.cli.embedded.get_subtitle_tracks", return_value=[])
+    mock_save = mocker.patch("koffee.cli.commands._save_raw_transcription")
+    mocker.patch("koffee.cli.commands.Confirm.ask", return_value=True)
+    mocker.patch("koffee.cli.commands.sys.stdin.isatty", return_value=True)
+
+    cli(korean_video_path, output_dir=output_directory_path)
+
+    mock_save.assert_called_once()
+
+
+def test_translation_failure_prompt_no_does_not_save(mocker: MockerFixture) -> None:
+    """Tests that answering no at the prompt skips the save."""
+    mocker.patch(
+        "koffee.cli.commands.run", side_effect=TranslationError("boom", segments=[])
+    )
+    mocker.patch("koffee.cli.embedded.get_subtitle_tracks", return_value=[])
+    mock_save = mocker.patch("koffee.cli.commands._save_raw_transcription")
+    mocker.patch("koffee.cli.commands.Confirm.ask", return_value=False)
+    mocker.patch("koffee.cli.commands.sys.stdin.isatty", return_value=True)
+
+    cli(
+        korean_video_path,
+        korean_video_path,
+        output_dir=output_directory_path,
+    )
+
+    mock_save.assert_not_called()
+
+
+def test_translation_failure_save_skips_prompt(mocker: MockerFixture) -> None:
+    """Tests that --on-translation-failure=save bypasses the prompt entirely."""
+    mocker.patch(
+        "koffee.cli.commands.run", side_effect=TranslationError("boom", segments=[])
+    )
+    mocker.patch("koffee.cli.embedded.get_subtitle_tracks", return_value=[])
+    mock_save = mocker.patch("koffee.cli.commands._save_raw_transcription")
+    mock_confirm = mocker.patch("koffee.cli.commands.Confirm.ask")
+
+    cli(
+        korean_video_path,
+        output_dir=output_directory_path,
+        on_translation_failure="save",
+    )
+
+    mock_confirm.assert_not_called()
+    mock_save.assert_called_once()
+
+
+def test_translation_failure_abort_skips_prompt_and_save(mocker: MockerFixture) -> None:
+    """Tests that --on-translation-failure=abort skips both the prompt and the save."""
+    mocker.patch(
+        "koffee.cli.commands.run", side_effect=TranslationError("boom", segments=[])
+    )
+    mocker.patch("koffee.cli.embedded.get_subtitle_tracks", return_value=[])
+    mock_save = mocker.patch("koffee.cli.commands._save_raw_transcription")
+    mock_confirm = mocker.patch("koffee.cli.commands.Confirm.ask")
+
+    cli(
+        korean_video_path,
+        output_dir=output_directory_path,
+        on_translation_failure="abort",
+    )
+
+    mock_confirm.assert_not_called()
+    mock_save.assert_not_called()
+
+
+def test_translation_failure_non_tty_falls_back_to_save(mocker: MockerFixture) -> None:
+    """Tests that a non-TTY stdin auto-saves instead of attempting a prompt."""
+    mocker.patch(
+        "koffee.cli.commands.run", side_effect=TranslationError("boom", segments=[])
+    )
+    mocker.patch("koffee.cli.embedded.get_subtitle_tracks", return_value=[])
+    mock_save = mocker.patch("koffee.cli.commands._save_raw_transcription")
+    mock_confirm = mocker.patch("koffee.cli.commands.Confirm.ask")
+    mocker.patch("koffee.cli.commands.sys.stdin.isatty", return_value=False)
+
+    cli(korean_video_path, output_dir=output_directory_path)
+
+    mock_confirm.assert_not_called()
+    mock_save.assert_called_once()
+
+
+def test_batch_continues_after_translation_failure(mocker: MockerFixture) -> None:
+    """Tests that a translation failure on one file does not stop later files."""
+    mock_run = mocker.patch(
+        "koffee.cli.commands.run",
+        side_effect=[TranslationError("boom", segments=[]), None, None],
+    )
+    mocker.patch("koffee.cli.embedded.get_subtitle_tracks", return_value=[])
+    mocker.patch("koffee.cli.commands._save_raw_transcription")
+    mocker.patch("koffee.cli.commands.Confirm.ask", return_value=True)
+    mocker.patch("koffee.cli.commands.sys.stdin.isatty", return_value=True)
+
+    cli(
+        korean_video_path,
+        korean_video_path,
+        korean_video_path,
+        output_dir=output_directory_path,
+    )
+
+    assert mock_run.call_count == 3
 
 
 def test_prompt_flag(mocker: MockerFixture) -> None:


### PR DESCRIPTION
The y/n prompt that fires after a translation failure was being drawn
underneath the active Rich Progress Live and effectively invisible, so
users got no chance to save the raw transcription before the outer
handler logged the file as failed.

- Add on_translation_failure config option and --on-translation-failure
  CLI flag with values prompt, save, abort (default prompt)
- Restructure the failure path so the prompt no longer runs inside
  _translate_with_progress; _run_batch dispatches to a new
  _handle_translation_failure helper that decides save vs abort vs prompt
- Use rich.prompt.Confirm.ask with the progress's console so the Live
  pauses for stdin reads instead of redrawing over the prompt
- Fall back to save when stdin is not a TTY so piped/CI runs do not lose
  the raw transcription
- Cover all branches with unit tests in tests/test_cli.py
- Document the flag in the README parameters section