### PR TITLE
Fix save transcription prompt working properly upon failure

### DIFF
--- a/koffee/cli/commands.py
+++ b/koffee/cli/commands.py
@@ -266,11 +266,13 @@ def _handle_translation_failure(
         return False
 
     if decision == "prompt":
+        progress.stop()
         save = Confirm.ask(
             "Save transcription as subtitles for manual retry?",
-            default=False,
+            default=True,
             console=progress.console,
         )
+        progress.start()
         if not save:
             return False
 


### PR DESCRIPTION
Currently, Rich's progress bar continuously redraws the terminal even upon an error, corrupting any prompt rendered beneath it. Calling input() while it runs overrides the prompt to save the transcription. 

This fix stops Rich before invoking input() and restart it after, while changing the default from no to yes so that an accidental empty response still saves the hard work that the ASR did.