### PR TITLE
Raise ValueError when Gemini returns no candidates

### DIFF
--- a/koffee/llm/gemini.py
+++ b/koffee/llm/gemini.py
@@ -25,6 +25,9 @@ def attempt_generate(client, prompt: str, model: str, system_prompt: str):
             "system_instruction": system_prompt,
         },
     )
+    if not response.candidates:
+        block_reason = getattr(response.prompt_feedback, "block_reason", "unknown")
+        raise ValueError(f"Gemini returned no candidates (block_reason={block_reason})")
     usage = response.usage_metadata
     log.debug(
         f"Gemini usage — prompt: {usage.prompt_token_count}, "


### PR DESCRIPTION
When the Gemini API declines to generate (safety block or other backend refusal), `response.candidates` is `None`. The debug log was indexing into it unconditionally, producing a confusing `TypeError` that bypassed retry logic entirely. Now raises a `ValueError` with the `block_reason` from `prompt_feedback` before touching candidates.