### PR TITLE
Fix macOS ffmpeg install to use evermeet.cx static build instead of Homebrew

### DIFF
--- a/.github/actions/setup-ffmpeg/action.yml
+++ b/.github/actions/setup-ffmpeg/action.yml
@@ -1,9 +1,9 @@
 name: Set up ffmpeg
 description: >-
-  Installs ffmpeg using the runner's native package manager (apt on Linux,
-  Homebrew on macOS, Chocolatey on Windows), with backoff retries. This avoids
-  third-party actions that download from a single upstream host, which rate
-  limits GitHub IPs and causes frequent CI flakes.
+  Installs ffmpeg with backoff retries. Linux uses apt; macOS downloads a
+  static build from evermeet.cx (same source as FedericoCarboni/setup-ffmpeg,
+  includes libass); Windows uses Chocolatey. Avoids johnvansickle.com, which
+  rate-limits GitHub IPs on Linux and caused frequent CI flakes.
 
 runs:
   using: composite
@@ -25,8 +25,13 @@ runs:
       if: runner.os == 'macOS'
       shell: bash
       run: |
+        FFMPEG_URL="https://evermeet.cx/ffmpeg/getrelease/ffmpeg/zip"
+        FFPROBE_URL="https://evermeet.cx/ffmpeg/getrelease/ffprobe/zip"
         for attempt in 1 2 3; do
-          if brew install ffmpeg; then
+          if curl -fsSL "$FFMPEG_URL" -o /tmp/ffmpeg.zip \
+              && curl -fsSL "$FFPROBE_URL" -o /tmp/ffprobe.zip \
+              && unzip -o /tmp/ffmpeg.zip -d /usr/local/bin \
+              && unzip -o /tmp/ffprobe.zip -d /usr/local/bin; then
             break
           fi
           echo "ffmpeg install attempt ${attempt} failed; retrying in $((attempt * 15))s" >&2


### PR DESCRIPTION
`brew install ffmpeg` installs a dynamically-linked build that fails the subtitles= filter in CI (fontconfig/libass not set up in the headless environment). Switch macOS to download directly from `evermeet.cx`, which is the same source the old FedericoCarboni/setup-ffmpeg action used, ie static build with libass compiled in.